### PR TITLE
Change on Btnr - Solving AttributeError

### DIFF
--- a/pyxel/app.py
+++ b/pyxel/app.py
@@ -119,7 +119,7 @@ class App:
                 (self._module.frame_count - press_frame - hold) % period == 0)
 
     def btnr(self, key):
-        return self._key_state.get(key, 0) == -self.module._frame_count
+        return self._key_state.get(key, 0) == -self._module.frame_count
 
     def run(self, update, draw):
         self._update = update


### PR DESCRIPTION
Changed line 122 on app.py from self.module._frame_count to self._module.frame_count

That would cause AttributeError: module "pyxel" has no attribute "_frame_count" when you tried to use the btnr function.