### PR TITLE
Typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ pip3 install pyxel
 
 ### Install examples
 
-After installing Pyxel, the examples of Pyxel will be copied to the current directory with the folloing command:
+After installing Pyxel, the examples of Pyxel will be copied to the current directory with the following command:
 
 ```sh
 install_pyxel_examples


### PR DESCRIPTION
Tiny typo on README.md file.
There was a "folloing" instead of "following" on line 80.