### PR TITLE
Update installation instructions for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Install the required packages in a way appropriate for each distribution.
 
 **Arch:**
 
+Install [`python-pixel`](https://aur.archlinux.org/packages/python-pyxel/) by using your favorite AUR helper:
+
 ```sh
-pacman -S python python-pip glfw portaudio
-pip install pyxel
+yay -S python-pyxel
 ```
 
 **Debian:**


### PR DESCRIPTION
* [python-glfw](https://www.archlinux.org/packages/community/any/python-glfw/) has been fixed and moved to [community].
* [python-pyxel](https://aur.archlinux.org/packages/python-pyxel/) is now in place in AUR.

It will take a few minutes until the AUR system detects that python-glfw is now in [community].