### PR TITLE
Hint to reduce the size of the captured GIF

### DIFF
--- a/pyxel/app.py
+++ b/pyxel/app.py
@@ -470,7 +470,7 @@ class App:
     def _save_capture_image(self):
         index = (self._capture_index - 1) % APP_GIF_CAPTURE_COUNT
         image = self._get_capture_image(index)
-        image.save(self._get_capture_filename() + ".png")
+        image.save(self._get_capture_filename() + ".png", optimize=True)
 
     def _save_capture_animation(self):
         image_count = min(


### PR DESCRIPTION
This should help the problem described in #7. This is just a simple trick that only works with PNGs.

There are still other ways to achieve this, but the only other methods I know are probably going to impact a lot on the final quality.