### PR TITLE
Prevent crash caused by 'fn' keypress on macOS

### DIFF
--- a/pyxel/app.py
+++ b/pyxel/app.py
@@ -353,7 +353,7 @@ class App:
         if action == glfw.PRESS:
             state = pyxel.frame_count
         elif action == glfw.RELEASE:
-            if self._key_state[key] == pyxel.frame_count:
+            if self._key_state.get(key) == pyxel.frame_count:
                 state = -pyxel.frame_count - 1
             else:
                 state = -pyxel.frame_count


### PR DESCRIPTION
This is a small fix to address #94, changing `self._key_state[key]` to `self._key_state.get(key)`