### PR TITLE
Fix crash on minimize

### DIFF
--- a/pyxel/app.py
+++ b/pyxel/app.py
@@ -431,8 +431,9 @@ class App:
 
     def _update_mouse_pos(self):
         x, y = glfw.get_cursor_pos(self._window)
-        pyxel.mouse_x = int((x - self._viewport_left) / self._viewport_scale)
-        pyxel.mouse_y = int((y - self._viewport_top) / self._viewport_scale)
+        if self._viewport_scale > 0:
+            pyxel.mouse_x = int((x - self._viewport_left) / self._viewport_scale)
+            pyxel.mouse_y = int((y - self._viewport_top) / self._viewport_scale)
 
     def _update_gamepad(self):
         for i in range(2):


### PR DESCRIPTION
Fixes Pyxel crashing with the following error:

```
Traceback (most recent call last):
  File ".\06_click_game.py", line 130, in <module>
    App()
  File ".\06_click_game.py", line 58, in __init__
    pyxel.run(self.update, self.draw)
  File "D:\Dropbox\code\pyxel\pyxel\app.py", line 252, in run
    main_loop()
  File "D:\Dropbox\code\pyxel\pyxel\app.py", line 244, in main_loop
    self._update_frame()
  File "D:\Dropbox\code\pyxel\pyxel\app.py", line 419, in _update_frame
    self._update_mouse_pos()
  File "D:\Dropbox\code\pyxel\pyxel\app.py", line 434, in _update_mouse_pos
    pyxel.mouse_x = int((x - self._viewport_left) / self._viewport_scale)
ZeroDivisionError: float division by zero
```

Steps to reproduce (on Windows 10):

1. Start any game, for instance `01_hello_pyxel.py` or `06_click_game.py` from examples
1. Minimize the window
1. Observe `ZeroDivisionError`

P.S. Many thanks for building this engine, it's great fun tinkering with it! 🙇 