### PR TITLE
Set non-zero refresh rate for glfw.set_window_monitor calls

### DIFF
--- a/pyxel/app.py
+++ b/pyxel/app.py
@@ -487,7 +487,7 @@ class App:
 
     def _toggle_fullscreen(self):
         if glfw.get_window_monitor(self._window):  # fullscreen to window
-            glfw.set_window_monitor(self._window, None, *self._window_info, 0)
+            glfw.set_window_monitor(self._window, None, *self._window_info, 60)
         else:  # window to fullscreen
             info = [0] * 4
             info[0], info[1] = glfw.get_window_pos(self._window)
@@ -496,7 +496,7 @@ class App:
 
             monitor = glfw.get_primary_monitor()
             size = glfw.get_video_mode(monitor)[0]
-            glfw.set_window_monitor(self._window, monitor, 0, 0, *size, 0)
+            glfw.set_window_monitor(self._window, monitor, 0, 0, *size, 60)
 
     def _check_special_input(self):
         if self.btn(KEY_ALT):

--- a/pyxel/app.py
+++ b/pyxel/app.py
@@ -487,7 +487,7 @@ class App:
 
     def _toggle_fullscreen(self):
         if glfw.get_window_monitor(self._window):  # fullscreen to window
-            glfw.set_window_monitor(self._window, None, *self._window_info, 60)
+            glfw.set_window_monitor(self._window, None, *self._window_info, glfw.DONT_CARE)
         else:  # window to fullscreen
             info = [0] * 4
             info[0], info[1] = glfw.get_window_pos(self._window)
@@ -496,7 +496,7 @@ class App:
 
             monitor = glfw.get_primary_monitor()
             size = glfw.get_video_mode(monitor)[0]
-            glfw.set_window_monitor(self._window, monitor, 0, 0, *size, 60)
+            glfw.set_window_monitor(self._window, monitor, 0, 0, *size, glfw.DONT_CARE)
 
     def _check_special_input(self):
         if self.btn(KEY_ALT):


### PR DESCRIPTION
This is a simple fix for #99

I tested it with a simple app and verified that it no longer crashes when I enter fullscreen mode, and the functionality of everything else appears to be the same.  I am well outside my comfort zone when it comes to working with game engines, so please let me know if there's any way I can make this fix more robust.

