### PR TITLE
Clean up code

### DIFF
--- a/pyxel/app.py
+++ b/pyxel/app.py
@@ -320,18 +320,18 @@ class App:
         image_list = data.get("image")
         if image_list:
             for i in range(RENDERER_IMAGE_COUNT - 1):
-                pyxel.image(i).data[:, :] = np.loads(image_list[i])
+                pyxel.image(i).data[:, :] = pickle.loads(image_list[i])
 
         tilemap_list = data.get("tilemap")
         if tilemap_list:
             if type(tilemap_list[0]) is tuple:
                 for i in range(RENDERER_TILEMAP_COUNT):
                     tilemap = pyxel.tilemap(i)
-                    tilemap.data[:, :] = np.loads(tilemap_list[i][0])
+                    tilemap.data[:, :] = pickle.loads(tilemap_list[i][0])
                     tilemap.refimg = tilemap_list[i][1]
             else:  # todo: delete this block in the future
                 for i in range(RENDERER_TILEMAP_COUNT):
-                    pyxel.tilemap(i).data[:, :] = np.loads(tilemap_list[i])
+                    pyxel.tilemap(i).data[:, :] = pickle.loads(tilemap_list[i])
 
         sound_list = data.get("sound")
         if sound_list:

--- a/pyxel/app.py
+++ b/pyxel/app.py
@@ -278,7 +278,8 @@ class App:
     def quit(self):
         glfw.set_window_should_close(self._window, True)
 
-    def save(self, filename):
+    @staticmethod
+    def save(filename):
         data = {"version": pyxel.VERSION}
 
         image_list = [
@@ -306,7 +307,8 @@ class App:
         with gzip.open(filename, mode="wb") as fp:
             fp.write(pickled_data)
 
-    def load(self, filename):
+    @staticmethod
+    def load(filename):
         dirname = os.path.dirname(inspect.stack()[-1].filename)
         filename = os.path.join(dirname, filename)
 
@@ -557,12 +559,14 @@ class App:
             palette=get_palette(fill=False),
         )
 
-    def _get_color_palette_index(self, image, color):
+    @staticmethod
+    def _get_color_palette_index(image, color):
         palette = image.getpalette()
         palette_colors = list(zip(palette[::3], palette[1::3], palette[2::3]))
         return palette_colors.index(color)
 
-    def _difference(self, prev, curr):
+    @staticmethod
+    def _difference(prev, curr):
         prev = np.asarray(prev.convert("RGBA"))
         curr = np.asarray(curr.convert("RGBA"))
         alpha = np.any(prev != curr, axis=-1, keepdims=True)

--- a/pyxel/editor/drawing_panel.py
+++ b/pyxel/editor/drawing_panel.py
@@ -91,7 +91,7 @@ class DrawingPanel(Widget):
             self._select_y1 = self._select_y2 = y
         elif self.parent.tool == TOOL_PENCIL:
             self._overlay_canvas.pix(x, y, self.parent.color)
-        elif self.parent.tool >= TOOL_RECTB and self.parent.tool <= TOOL_CIRC:
+        elif TOOL_RECTB <= self.parent.tool <= TOOL_CIRC:
             self._overlay_canvas.rect(x, y, x, y, self.parent.color, False)
         elif self.parent.tool == TOOL_BUCKET:
             data = (
@@ -119,7 +119,7 @@ class DrawingPanel(Widget):
 
         self._is_dragged = False
 
-        if self.parent.tool >= TOOL_PENCIL and self.parent.tool <= TOOL_CIRC:
+        if TOOL_PENCIL <= self.parent.tool <= TOOL_CIRC:
             data = (
                 pyxel.tilemap(self.parent.tilemap).data
                 if self._is_tilemap_mode

--- a/pyxel/editor/piano_keyboard.py
+++ b/pyxel/editor/piano_keyboard.py
@@ -61,15 +61,15 @@ class PianoKeyboard(Widget):
             return -1
 
         if x <= 6:
-            if y >= 2 and y <= 4:
+            if 2 <= y <= 4:
                 return octave + 10
-            elif y >= 6 and y <= 8:
+            elif 6 <= y <= 8:
                 return octave + 8
-            elif y >= 10 and y <= 12:
+            elif 10 <= y <= 12:
                 return octave + 6
-            elif y >= 16 and y <= 18:
+            elif 16 <= y <= 18:
                 return octave + 3
-            elif y >= 20 and y <= 22:
+            elif 20 <= y <= 22:
                 return octave + 1
 
         if y <= 2:

--- a/pyxel/examples/02_jump_game.py
+++ b/pyxel/examples/02_jump_game.py
@@ -81,7 +81,7 @@ class App:
             y = randint(8, 104)
             is_active = True
 
-        return (x, y, is_active)
+        return x, y, is_active
 
     def update_fruit(self, x, y, kind, is_active):
         if is_active and abs(x - self.player_x) < 12 and abs(y - self.player_y) < 12:

--- a/pyxel/gl_wrapper.py
+++ b/pyxel/gl_wrapper.py
@@ -160,6 +160,7 @@ class GLTexture:
         gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, self._filter)
         gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
 
-    def _end(self, i):
+    @staticmethod
+    def _end(i):
         gl.glActiveTexture(gl.GL_TEXTURE0 + i)
         gl.glBindTexture(gl.GL_TEXTURE_2D, 0)

--- a/pyxel/renderer.py
+++ b/pyxel/renderer.py
@@ -179,4 +179,4 @@ class Renderer:
 
     @staticmethod
     def _int_to_rgb(color):
-        return ((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF)
+        return (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF

--- a/pyxel/sound.py
+++ b/pyxel/sound.py
@@ -52,7 +52,7 @@ class Sound:
                     c = data[0]
                     data = data[1:]
 
-                if c >= "0" and c <= "4":
+                if "0" <= c <= "4":
                     param += int(c) * 12
                 else:
                     raise ValueError("invalid sound note")
@@ -90,7 +90,7 @@ class Sound:
             c = data[0]
             data = data[1:]
 
-            if c >= "0" and c <= "7":
+            if "0" <= c <= "7":
                 param = int(c)
             else:
                 raise ValueError("invalid sound volume")

--- a/pyxel/ui/color_picker.py
+++ b/pyxel/ui/color_picker.py
@@ -43,7 +43,7 @@ class ColorPicker(Widget):
         x2 = x1 + 6
         y2 = x2 + 6
 
-        if x >= x1 and x <= x2 and y >= y1 and y <= y2:
+        if x1 <= x <= x2 and y1 <= y <= y2:
             return index_y * 8 + index_x
 
         return None

--- a/pyxel/ui/radio_button.py
+++ b/pyxel/ui/radio_button.py
@@ -48,7 +48,7 @@ class RadioButton(Widget):
         x2 = x1 + 6
         y2 = y1 + 6
 
-        if x >= x1 and x <= x2 and y >= y1 and y <= y2:
+        if x1 <= x <= x2 and y1 <= y <= y2:
             return index
 
         return None

--- a/pyxel/ui/widget.py
+++ b/pyxel/ui/widget.py
@@ -171,7 +171,8 @@ class Widget:
         self._height = height
         self.call_event_handler("resize", width, height)
 
-    def draw_panel(self, x, y, width, height, *, with_shadow=True):
+    @staticmethod
+    def draw_panel(x, y, width, height, *, with_shadow=True):
         x1 = x
         y1 = y
         x2 = x + width - 1
@@ -193,7 +194,8 @@ class Widget:
         Widget._capture_info.press_pos = (pyxel.mouse_x, pyxel.mouse_y)
         Widget._capture_info.last_pos = Widget._capture_info.press_pos
 
-    def _release_mouse(self):
+    @staticmethod
+    def _release_mouse():
         Widget._capture_info.widget = None
         Widget._capture_info.key = None
         Widget._capture_info.time = None

--- a/pyxel/ui/widget.py
+++ b/pyxel/ui/widget.py
@@ -137,10 +137,8 @@ class Widget:
 
     def is_hit(self, x, y):
         return (
-            x >= self._x
-            and x <= self._x + self._width - 1
-            and y >= self._y
-            and y <= self._y + self._height - 1
+                self._x <= x <= self._x + self._width - 1
+                and self._y <= y <= self._y + self._height - 1
         )
 
     def move(self, x, y):


### PR DESCRIPTION
Got to work on some of the issues, and cleaned up the code a little while I was at it.
Chaining the comparisons should actually make it faster, since it saves one evaluation per `and` saved.
`np.loads` is deprecated, so I replaced it with `pickle.loads`, as per the warning.
Using the `@staticmethod` decorator is useful for semantic reasoning