### PR TITLE
Fix errors that occur when run pyxelpackager

### DIFF
--- a/pyxel/packager.py
+++ b/pyxel/packager.py
@@ -25,8 +25,8 @@ def run():
 
     args = parser.parse_args()
 
-    dirname = os.path.dirname(args.entrypoint.name) or "."
-    filename = os.path.basename(args.entrypoint.name)
+    dirname = os.path.dirname(args.python_file.name) or "."
+    filename = os.path.basename(args.python_file.name)
     name = os.path.splitext(filename)[0]
     separator = ";" if platform.system() == "Windows" else ":"
 


### PR DESCRIPTION
The following error occurs when running the pyxelpackager:

```
Traceback (most recent call last):
  File "c:\users\liri\appdata\local\programs\python\python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\users\liri\appdata\local\programs\python\python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\Liri\AppData\Local\Programs\Python\Python37\Scripts\pyxelpackager.exe\__main__.py", line 9, in <module>
  File "c:\users\liri\appdata\local\programs\python\python37\lib\site-packages\pyxel\packager.py", line 28, in run
    dirname = os.path.dirname(args.entrypoint.name) or "."
AttributeError: 'Namespace' object has no attribute 'entrypoint'
```

This is because the argument was renamed from `entrypoint` to `python_file` in a recent commit. 3392f1b
I put in a commit that solved this.