### PR TITLE
Change from sudo pip3 to sudo -H pip3

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -79,7 +79,7 @@ pip3 install -U pyxel
 
 ```sh
 sudo apt install python3 python3-pip libsdl2-dev libsdl2-image-dev
-sudo pip3 install -U pyxel
+sudo -H pip3 install -U pyxel
 ```
 
 ### 其他环境

--- a/README.ja.md
+++ b/README.ja.md
@@ -80,7 +80,7 @@ pip3 install -U pyxel
 
 ```sh
 sudo apt install python3 python3-pip libsdl2-dev libsdl2-image-dev
-sudo pip3 install -U pyxel
+sudo -H pip3 install -U pyxel
 ```
 
 ### その他の環境

--- a/README.ko.md
+++ b/README.ko.md
@@ -80,7 +80,7 @@ pip3 install -U pyxel
 
 ```sh
 sudo apt install python3 python3-pip libsdl2-dev libsdl2-image-dev
-sudo pip3 install -U pyxel
+sudo -H pip3 install -U pyxel
 ```
 
 ### 기타 환경

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Install [Python3](https://www.python.org/) (version 3.7 or higher) and the requi
 
 ```sh
 sudo apt install python3 python3-pip libsdl2-dev libsdl2-image-dev
-sudo pip3 install -U pyxel
+sudo -H pip3 install -U pyxel
 ```
 
 ### Other environment


### PR DESCRIPTION
`sudo pip3 install -U pyxel`とするとpipが
> If executing pip with sudo, you may want sudo's -H flag.

と警告してくるので(必須ではないけど)sudoに`-H`オプションをつけたほうがよろしいかと。

When run `sudo pip3 install -U pyxel`, pip will warn
> If executing pip with sudo, you may want sudo's -H flag.

(although it is not required), I think it's better to add the `-H` option to sudo.
Translated from Japanese to English by Google Translate.