### PR TITLE
Properly resize screen to fill window

### DIFF
--- a/pyxel/core/include/pyxelcore/window.h
+++ b/pyxel/core/include/pyxelcore/window.h
@@ -39,7 +39,7 @@ class Window {
   int32_t screen_y_;
   int32_t screen_width_;
   int32_t screen_height_;
-  int32_t screen_scale_;
+  float screen_scale_;
   PaletteColor palette_color_;
   bool is_fullscreen_;
   int32_t mouse_wheel_;

--- a/pyxel/core/src/pyxelcore/window.cc
+++ b/pyxel/core/src/pyxelcore/window.cc
@@ -86,9 +86,10 @@ void Window::UpdateWindowInfo() {
   SDL_GetWindowSize(window_, &window_width, &window_height);
 
   screen_scale_ =
-      Min(window_width / screen_width_, window_height / screen_height_);
-  screen_x_ = (window_width - screen_width_ * screen_scale_) / 2;
-  screen_y_ = (window_height - screen_height_ * screen_scale_) / 2;
+      Min(float(window_width) / float(screen_width_),
+          float(window_height) / float(screen_height_));
+  screen_x_ = int32_t((float(window_width) - float(screen_width_) * screen_scale_) / 2.0);
+  screen_y_ = int32_t((float(window_height) - float(screen_height_) * screen_scale_) / 2.0);
 }
 
 void Window::ToggleFullscreen() {
@@ -141,8 +142,8 @@ void Window::Render(int32_t** screen_data) {
   SDL_Rect dst_rect = {
       screen_x_,
       screen_y_,
-      screen_width_ * screen_scale_,
-      screen_height_ * screen_scale_,
+      int32_t(float(screen_width_) * screen_scale_),
+      int32_t(float(screen_height_) * screen_scale_),
   };
 
   SDL_RenderCopy(renderer_, screen_texture_, NULL, &dst_rect);


### PR DESCRIPTION
This PR addresses #269 

When computing screen scale, integer division is going to floor, resulting in a quantized screen scaling effect. By doing all scaling math with floating point, then casting the result, we will always fill the width or height fully, while keeping the resulting screen drawing to integers.

Before:
<img width="1035" alt="before" src="https://user-images.githubusercontent.com/30034160/100532715-a3f9e300-31b0-11eb-9a35-e6ec825c8809.png">

After:
<img width="909" alt="after" src="https://user-images.githubusercontent.com/30034160/100532712-a0665c00-31b0-11eb-9dfb-f0738d909fa3.png">
