### PR TITLE
Pause Mouse When Window Minimized, Lost Focus, Hidden

### DIFF
--- a/pyxel/core/include/pyxelcore/input.h
+++ b/pyxel/core/include/pyxelcore/input.h
@@ -21,9 +21,12 @@ class Input {
                        int32_t hold_frame = 0,
                        int32_t period_frame = 0) const;
   bool IsButtonReleased(int32_t key) const;
+  void SetMousePaused(int32_t is_paused);
   void SetMouseVisible(int32_t is_visible);
 
-  bool IsMouseVisible() const { return is_mouse_visible_; }
+  bool IsMousePaused() const { return is_mouse_paused_; }
+  bool IsMouseVisible() const { return is_mouse_visible_ || is_mouse_paused_; }
+
   void Update(Window* window, int32_t frame_count);
 
  private:
@@ -36,6 +39,7 @@ class Input {
   int32_t mouse_x_;
   int32_t mouse_y_;
   int32_t mouse_wheel_;
+  bool is_mouse_paused_;
   bool is_mouse_visible_;
   int32_t key_state_[KEY_COUNT];
 

--- a/pyxel/core/include/pyxelcore/window.h
+++ b/pyxel/core/include/pyxelcore/window.h
@@ -3,6 +3,12 @@
 
 #include "pyxelcore/common.h"
 
+// Events on the window might need system-level actions to be performed
+#define WINDOW_ACTION_NONE          0
+#define WINDOW_ACTION_CLOSE         (1u << 0)  // close the window
+#define WINDOW_ACTION_PAUSE_CURSOR  (1u << 1)  // window is inactive, so don't respond to cursor movements
+#define WINDOW_ACTION_RESUME_CURSOR (1u << 2)  // start moving cursor again
+
 namespace pyxelcore {
 
 class Window {
@@ -22,7 +28,7 @@ class Window {
   int32_t ScreenScale() const { return screen_scale_; }
 
   void ToggleFullscreen();
-  bool ProcessEvents();
+  uint32_t ProcessEvents();
   void Render(int32_t** screen_data);
   int32_t GetMouseWheel();
   std::string GetDropFile();
@@ -45,6 +51,7 @@ class Window {
   int32_t mouse_wheel_;
   std::string drop_file_;
 
+  uint32_t ProcessWindowEvent(SDL_Event event);
   void SetupWindowIcon() const;
   void UpdateWindowInfo();
   void UpdateScreenTexture(int32_t** screen_data);

--- a/pyxel/core/src/pyxelcore/input.cc
+++ b/pyxel/core/src/pyxelcore/input.cc
@@ -36,6 +36,11 @@ Input::~Input() {
 }
 
 void Input::Update(Window* window, int32_t frame_count) {
+  if (is_mouse_paused_) {
+    // stop updating any state because we should be ignoring mouse input
+    return;
+  }
+
   frame_count_ = frame_count + 1;  // change frame_count to start from 1
 
   SDL_GetGlobalMouseState(&mouse_x_, &mouse_y_);
@@ -145,8 +150,11 @@ bool Input::IsButtonReleased(int32_t key) const {
   return key_state_[key] == -frame_count_;
 }
 
+void Input::SetMousePaused(int32_t is_paused) {
+  is_mouse_paused_ = is_paused;
+}
+
 void Input::SetMouseVisible(int32_t is_visible) {
   is_mouse_visible_ = is_visible;
 }
-
 }  // namespace pyxelcore

--- a/pyxel/core/src/pyxelcore/system.cc
+++ b/pyxel/core/src/pyxelcore/system.cc
@@ -191,8 +191,15 @@ bool System::UpdateFrame(void (*update)()) {
 
   update_profiler_.Start();
 
-  if (window_->ProcessEvents()) {
+  uint32_t action_flag = window_->ProcessEvents();
+  if (action_flag & WINDOW_ACTION_CLOSE) {
     return true;
+  }
+
+  if (action_flag & WINDOW_ACTION_PAUSE_CURSOR) {
+    input_->SetMousePaused(true);
+  } else if (action_flag & WINDOW_ACTION_RESUME_CURSOR) {
+    input_->SetMousePaused(false);
   }
 
   drop_file_ = window_->GetDropFile();

--- a/pyxel/core/src/pyxelcore/window.cc
+++ b/pyxel/core/src/pyxelcore/window.cc
@@ -98,17 +98,14 @@ void Window::ToggleFullscreen() {
                           is_fullscreen_ ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
 }
 
-bool Window::ProcessEvents() {
+uint32_t Window::ProcessEvents() {
   SDL_Event event;
-  bool window_should_close = false;
+  uint32_t action_flag = WINDOW_ACTION_NONE;
 
   while (SDL_PollEvent(&event)) {
     switch (event.type) {
       case SDL_WINDOWEVENT:
-        if (event.window.event == SDL_WINDOWEVENT_MOVED ||
-            event.window.event == SDL_WINDOWEVENT_RESIZED) {
-          UpdateWindowInfo();
-        }
+        action_flag = action_flag | ProcessWindowEvent(event);
         break;
 
       case SDL_MOUSEWHEEL:
@@ -120,12 +117,37 @@ bool Window::ProcessEvents() {
         break;
 
       case SDL_QUIT:
-        window_should_close = true;
+        action_flag = action_flag | WINDOW_ACTION_CLOSE;
         break;
     }
   }
 
-  return window_should_close;
+  return action_flag;
+}
+
+uint32_t Window::ProcessWindowEvent(SDL_Event event) {
+  uint32_t flag = WINDOW_ACTION_NONE;
+
+  switch(event.window.event) {
+    case SDL_WINDOWEVENT_MOVED:
+    case SDL_WINDOWEVENT_RESIZED:
+      UpdateWindowInfo();
+      break;
+
+    case SDL_WINDOWEVENT_MINIMIZED:
+    case SDL_WINDOWEVENT_FOCUS_LOST:
+    case SDL_WINDOWEVENT_HIDDEN:
+      flag = flag | WINDOW_ACTION_PAUSE_CURSOR;
+      break;
+
+    case SDL_WINDOWEVENT_MAXIMIZED:
+    case SDL_WINDOWEVENT_FOCUS_GAINED:
+    case SDL_WINDOWEVENT_SHOWN:
+      flag = flag | WINDOW_ACTION_RESUME_CURSOR;
+      break;
+  }
+
+  return flag;
 }
 
 void Window::Render(int32_t** screen_data) {


### PR DESCRIPTION
This PR addresses issue #260 

Added functionality that pauses/unpauses the mouse based on the SDL window event
Pauses the mouse on the following SDL window events: 
- SDL_WINDOWEVENT_HIDDEN
- SDL_WINDOWEVENT_MINIMIZED
- SDL_WINDOWEVENT_FOCUS_LOST

Resumes the mouse on the following SDL window events:
- SDL_WINDOWEVENT_MAXIMIZED
- SDL_WINDOWEVENT_FOCUS_GAINED
- SDL_WINDOWEVENT_SHOWN

Refactored how all SDL window events are handled. 