### PR TITLE
made SDL cursor pixel transparent

### DIFF
--- a/pyxel/core/src/pyxelcore/input.cc
+++ b/pyxel/core/src/pyxelcore/input.cc
@@ -11,7 +11,7 @@ Input::Input() {
   gamepad1_ = SDL_GameControllerOpen(0);
   gamepad2_ = SDL_GameControllerOpen(1);
 
-  const uint8_t data[] = {8};
+  const uint8_t data[] = {0};
   blank_cursor_ = SDL_CreateCursor(data, data, 1, 1, 0, 0);
   normal_cursor_ = SDL_GetCursor();
   SDL_SetCursor(blank_cursor_);


### PR DESCRIPTION
This addresses issue https://github.com/kitao/pyxel/issues/284 

It seems to me that a lot of the cursor code can be removed with things still working as intended (at least on OSX) but I wanted to scope my changes to only the issue.