### PR TITLE
Add `btns()` and `btnsp([hold], [interval])` to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,8 +357,14 @@ The current value of the mouse wheel
 - `btn(key)`<br>
 Return `True` if `key` is pressed, otherwise return `False` ([key definition list](pyxel/__init__.py))
 
+- `btns()`<br>
+Return a `List` of keys pressed at the current frame ([key definition list](pyxel/__init__.py))
+
 - `btnp(key, [hold], [period])`<br>
 Return `True` if `key` is pressed at that frame, otherwise return `False`. When `hold` and `period` are specified, `True` will be returned at the `period` frame interval when the `key` is held down for more than `hold` frames
+
+- `btnsp(key, [hold], [period])`<br>
+Return a `List` of keys pressed at the current frame. When `hold` and `period` are specified, returns a `List` of keys held down for more than `hold` frames at the `period` frame interval
 
 - `btnr(key)`<br>
 Return `True` if `key` is released at that frame, otherwise return `False`

--- a/README.md
+++ b/README.md
@@ -358,13 +358,13 @@ The current value of the mouse wheel
 Return `True` if `key` is pressed, otherwise return `False` ([key definition list](pyxel/__init__.py))
 
 - `btns()`<br>
-Return a `List` of keys pressed at the current frame ([key definition list](pyxel/__init__.py))
+Returns a `List` of keys pressed at the current frame ([key definition list](pyxel/__init__.py))
 
 - `btnp(key, [hold], [period])`<br>
 Return `True` if `key` is pressed at that frame, otherwise return `False`. When `hold` and `period` are specified, `True` will be returned at the `period` frame interval when the `key` is held down for more than `hold` frames
 
-- `btnsp(key, [hold], [period])`<br>
-Return a `List` of keys pressed at the current frame. When `hold` and `period` are specified, returns a `List` of keys held down for more than `hold` frames at the `period` frame interval
+- `btnsp([hold], [period])`<br>
+Returns a `List` of keys pressed at the current frame. When `hold` and `period` are specified, returns a `List` of keys held down for more than `hold` frames at the `period` frame interval
 
 - `btnr(key)`<br>
 Return `True` if `key` is released at that frame, otherwise return `False`

--- a/pyxel/__init__.py
+++ b/pyxel/__init__.py
@@ -651,6 +651,10 @@ def btns() -> List[int]:
 def btnp(key: int, hold: int = 0, period: int = 0) -> bool:
     return core.btnp(int(key), int(hold), int(period))  # type: ignore
 
+def btnsp(hold: int = 0, period: int = 0) -> List[int]:
+    btns_list = (c_int32 * KEY_COUNT)()
+    btns_count = core.btnsp(btns_list, c_int32(len(btns_list)), c_int32(hold), c_int32(period))
+    return list(btns_list)[0:btns_count]
 
 def btnr(key: int) -> bool:
     return core.btnr(int(key))  # type: ignore

--- a/pyxel/__init__.py
+++ b/pyxel/__init__.py
@@ -218,6 +218,7 @@ GAMEPAD_2_RIGHT: int = _get_constant_number("GAMEPAD_2_RIGHT")
 GAMEPAD_2_DOWN: int = _get_constant_number("GAMEPAD_2_DOWN")
 GAMEPAD_2_LEFT: int = _get_constant_number("GAMEPAD_2_LEFT")
 
+KEY_COUNT: int = _get_constant_number("KEY_COUNT")
 
 #
 # Image class
@@ -642,6 +643,10 @@ def mouse_wheel(mod):  # type: ignore
 def btn(key: int) -> bool:
     return core.btn(int(key))  # type: ignore
 
+def btns() -> List[int]:
+    btns_list = (c_int32 * KEY_COUNT)()
+    btns_count = core.btns(btns_list, c_int32(len(btns_list)))
+    return list(btns_list)[0:btns_count]
 
 def btnp(key: int, hold: int = 0, period: int = 0) -> bool:
     return core.btnp(int(key), int(hold), int(period))  # type: ignore

--- a/pyxel/core/__init__.py
+++ b/pyxel/core/__init__.py
@@ -88,6 +88,7 @@ _setup_api("mouse_wheel_getter", c_int32, [])
 _setup_api("btn", c_int32, [c_int32])
 _setup_api("btns", c_int32, [POINTER(c_int32), c_int32])
 _setup_api("btnp", c_int32, [c_int32] * 3)
+_setup_api("btnsp", c_int32, [POINTER(c_int32), c_int32, c_int32, c_int32])
 _setup_api("btnr", c_int32, [c_int32])
 _setup_api("mouse", None, [c_int32])
 

--- a/pyxel/core/__init__.py
+++ b/pyxel/core/__init__.py
@@ -86,6 +86,7 @@ _setup_api("mouse_y_getter", c_int32, [])
 _setup_api("mouse_wheel_getter", c_int32, [])
 
 _setup_api("btn", c_int32, [c_int32])
+_setup_api("btns", c_int32, [POINTER(c_int32), c_int32])
 _setup_api("btnp", c_int32, [c_int32] * 3)
 _setup_api("btnr", c_int32, [c_int32])
 _setup_api("mouse", None, [c_int32])

--- a/pyxel/core/include/pyxelcore.h
+++ b/pyxel/core/include/pyxelcore.h
@@ -66,6 +66,7 @@ PYXEL_API int mouse_wheel_getter();
 PYXEL_API int btn(int key);
 PYXEL_API int btns(int *keys, int len);
 PYXEL_API int btnp(int key, int hold, int period);
+PYXEL_API int btnsp(int *keys, int len, int hold, int period);
 PYXEL_API int btnr(int key);
 PYXEL_API void mouse(int visible);
 

--- a/pyxel/core/include/pyxelcore.h
+++ b/pyxel/core/include/pyxelcore.h
@@ -64,6 +64,7 @@ PYXEL_API int mouse_y_getter();
 PYXEL_API int mouse_wheel_getter();
 
 PYXEL_API int btn(int key);
+PYXEL_API int btns(int *keys, int len);
 PYXEL_API int btnp(int key, int hold, int period);
 PYXEL_API int btnr(int key);
 PYXEL_API void mouse(int visible);

--- a/pyxel/core/include/pyxelcore/input.h
+++ b/pyxel/core/include/pyxelcore/input.h
@@ -18,6 +18,10 @@ class Input {
 
   int32_t GetButtonsOn(int32_t *keys, int32_t len) const;
   bool IsButtonOn(int32_t key) const;
+  int32_t GetButtonsPressed(int32_t *keys,
+                            int32_t len,
+                            int32_t hold_frame = 0,
+                            int32_t period_frame = 0) const;
   bool IsButtonPressed(int32_t key,
                        int32_t hold_frame = 0,
                        int32_t period_frame = 0) const;

--- a/pyxel/core/include/pyxelcore/input.h
+++ b/pyxel/core/include/pyxelcore/input.h
@@ -16,6 +16,7 @@ class Input {
   int32_t MouseY() const { return mouse_y_; }
   int32_t MouseWheel() const { return mouse_wheel_; }
 
+  int32_t GetButtonsOn(int32_t *keys, int32_t len) const;
   bool IsButtonOn(int32_t key) const;
   bool IsButtonPressed(int32_t key,
                        int32_t hold_frame = 0,

--- a/pyxel/core/src/pyxelcore.cc
+++ b/pyxel/core/src/pyxelcore.cc
@@ -154,6 +154,10 @@ int btnp(int key, int hold, int period) {
   return GetInput()->IsButtonPressed(key, hold, period);
 }
 
+int btnsp(int *keys, int len, int hold, int period) {
+  return GetInput()->GetButtonsPressed(keys, hold, period);
+}
+
 int btnr(int key) {
   return GetInput()->IsButtonReleased(key);
 }

--- a/pyxel/core/src/pyxelcore.cc
+++ b/pyxel/core/src/pyxelcore.cc
@@ -146,6 +146,10 @@ int btn(int key) {
   return GetInput()->IsButtonOn(key);
 }
 
+int btns(int *keys, int len) {
+  return GetInput()->GetButtonsOn(keys, len);
+}
+
 int btnp(int key, int hold, int period) {
   return GetInput()->IsButtonPressed(key, hold, period);
 }

--- a/pyxel/core/src/pyxelcore/constants.cc
+++ b/pyxel/core/src/pyxelcore/constants.cc
@@ -198,6 +198,8 @@ int32_t GetConstantNumber(const std::string& name) {
   CHECK_CONSTANT(GAMEPAD_2_DOWN);
   CHECK_CONSTANT(GAMEPAD_2_LEFT);
 
+  CHECK_CONSTANT(KEY_COUNT);
+
   PYXEL_ERROR("unknown constant name '" + name + "'");
   return 0;
 }

--- a/pyxel/core/src/pyxelcore/input.cc
+++ b/pyxel/core/src/pyxelcore/input.cc
@@ -119,6 +119,22 @@ bool Input::IsButtonOn(int32_t key) const {
   return key_state_[key] > 0;
 }
 
+int32_t Input::GetButtonsPressed(int32_t *keys, int32_t len, int32_t hold_frame, int32_t period_frame) const {
+  int32_t j = 0;
+
+  for (int32_t i = 0; i < KEY_COUNT; i++) {
+    if (Input::IsButtonPressed(i, hold_frame, period_frame)) {
+      if (j >= len) {
+        return j;
+      }
+      keys[j] = i;
+      j++;
+    }
+  }
+
+  return j;
+}
+
 bool Input::IsButtonPressed(int32_t key,
                             int32_t hold_frame,
                             int32_t period_frame) const {

--- a/pyxel/core/src/pyxelcore/input.cc
+++ b/pyxel/core/src/pyxelcore/input.cc
@@ -95,6 +95,22 @@ void Input::Update(Window* window, int32_t frame_count) {
   }
 }
 
+int32_t Input::GetButtonsOn(int32_t *keys, int32_t len) const {
+  int32_t j = 0;
+  for (int32_t i = 0; i < KEY_COUNT; i++) {
+    if (Input::IsButtonOn(i)) {
+      if (j >= len) {
+        return j;
+      }
+
+      keys[j] = i;
+      j++;
+    }
+  }
+
+  return j;
+}
+
 bool Input::IsButtonOn(int32_t key) const {
   if (key < 0 || key >= KEY_COUNT) {
     PYXEL_ERROR("invalid key");


### PR DESCRIPTION
This PR addresses #271 

Added `btns` and `btnsp` to the Pyxel API:
- `btns()` - returns a list of keys pressed for the current frame
- `btnsp([hold], [interval])` - returns a of keys pressed at the current frame. When `hold` and `period` are specified, returns a list of keys held down for more than `hold` frames at the `period` frame interval 

Updated the README to include these