### PR TITLE
Make screen recording functionality optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,9 +322,9 @@ The width and height of the screen
 - `frame_count`<br>
 The number of the elapsed frames
 
-- `init(width, height, [caption], [scale], [palette], [fps], [quit_key], [fullscreen])`<br>
+- `init(width, height, [caption], [scale], [palette], [fps], [quit_key], [fullscreen], [recording_enabled])`<br>
 Initialize the Pyxel application with screen size (`width`, `height`). The maximum width and height of the screen is 256<br>
-It is also possible to specify the window title with `caption`, the display magnification with `scale`, the palette color with `palette`, the frame rate with `fps`, the key to quit the application with `quit_key`, and whether to start in full screen with `fullscreen`. `palette` is specified as a list of 16 elements of 24 bit color.<br>
+It is also possible to specify the window title with `caption`, the display magnification with `scale`, the palette color with `palette`, the frame rate with `fps`, the key to quit the application with `quit_key`, and whether to start in full screen with `fullscreen`. `palette` is specified as a list of 16 elements of 24 bit color. It is possible to disable screen recording functionality on low-spec systems by setting `recording_enabled` to `False`.<br>
 e.g. `pyxel.init(160, 120, caption="Pyxel with PICO-8 palette", palette=[0x000000, 0x1D2B53, 0x7E2553, 0x008751, 0xAB5236, 0x5F574F, 0xC2C3C7, 0xFFF1E8, 0xFF004D, 0xFFA300, 0xFFEC27, 0x00E436, 0x29ADFF, 0x83769C, 0xFF77A8, 0xFFCCAA], quit_key=pyxel.KEY_NONE, fullscreen=True)`
 
 - `run(update, draw)`<br>

--- a/pyxel/__init__.py
+++ b/pyxel/__init__.py
@@ -525,6 +525,7 @@ def init(
     fps: int = DEFAULT_FPS,
     quit_key: int = DEFAULT_QUIT_KEY,
     fullscreen: bool = False,
+    recording_enabled: bool = True
 ) -> None:
     _image_bank.clear()
     _tilemap_bank.clear()
@@ -542,6 +543,7 @@ def init(
         int(fps),
         int(quit_key),
         int(fullscreen),
+        int(recording_enabled)
     )
 
 

--- a/pyxel/core/__init__.py
+++ b/pyxel/core/__init__.py
@@ -62,7 +62,7 @@ _setup_api("height_getter", c_int32, [])
 _setup_api("frame_count_getter", c_int32, [])
 
 _setup_api(
-    "init", None, [c_int32] * 2 + [c_char_p, c_int32, c_int32 * 16] + [c_int32] * 3
+    "init", None, [c_int32] * 2 + [c_char_p, c_int32, c_int32 * 16] + [c_int32] * 4
 )
 _setup_api("run", None, [CFUNCTYPE(None)] * 2)
 _setup_api("quit", c_int32, [])

--- a/pyxel/core/include/pyxelcore.h
+++ b/pyxel/core/include/pyxelcore.h
@@ -37,7 +37,8 @@ PYXEL_API void init(int width,
                     const int* palette,
                     int fps,
                     int quit_key,
-                    int fullscreen);
+                    int fullscreen,
+                    int recording_enabled);
 PYXEL_API void run(void (*update)(), void (*draw)());
 PYXEL_API int quit();
 PYXEL_API int flip();

--- a/pyxel/core/include/pyxelcore/system.h
+++ b/pyxel/core/include/pyxelcore/system.h
@@ -21,7 +21,8 @@ class System {
          const pyxelcore::PaletteColor& palette_color,
          int32_t fps,
          int32_t quit_key,
-         bool is_fullscreen);
+         bool is_fullscreen,
+         bool is_recording_enabled);
   ~System();
 
   pyxelcore::Resource* Resource() const { return resource_; }

--- a/pyxel/core/src/pyxelcore.cc
+++ b/pyxel/core/src/pyxelcore.cc
@@ -62,14 +62,16 @@ void init(int width,
           const int* palette,
           int fps,
           int quit_key,
-          int fullscreen) {
+          int fullscreen,
+          int recording_enabled) {
   std::array<int, pyxelcore::COLOR_COUNT> palette_color;
   for (int i = 0; i < pyxelcore::COLOR_COUNT; i++) {
     palette_color[i] = palette[i];
   }
 
   s_system = new pyxelcore::System(width, height, std::string(caption), scale,
-                                   palette_color, fps, quit_key, fullscreen);
+                                   palette_color, fps, quit_key, fullscreen,
+                                   recording_enabled);
   s_resource = s_system->Resource();
   s_input = s_system->Input();
   s_graphics = s_system->Graphics();

--- a/pyxel/core/src/pyxelcore/system.cc
+++ b/pyxel/core/src/pyxelcore/system.cc
@@ -257,7 +257,7 @@ void System::DrawFrame(void (*draw)(), int32_t update_frame_count) {
   DrawMouseCursor();
 
   window_->Render(graphics_->ScreenImage()->Data());
-  if (recorder) {
+  if (recorder_) {
     recorder_->Update(graphics_->ScreenImage(), update_frame_count);
   }
 


### PR DESCRIPTION
This is a proposal for resolving issue [267](https://github.com/kitao/pyxel/issues/267)

It simply adds the possibility to turn off screen recording functionality to save memory on low-spec systems.
Newly introduced flag ```recording_enabled``` has been added to ```pyxel.init()```. To avoid confusion it's defaulted to ```True``` (so by default it pyxel behaves exactly like before)

If this PR will be accepted two additional things must be changed:
- All binaries (for all platforms) need to be rebuild,
- All README translations need to be updated to reflect configuration flag.
