### PR TITLE
Protect non-initialized access to pyxel module

### DIFF
--- a/pyxel/__init__.py
+++ b/pyxel/__init__.py
@@ -498,6 +498,7 @@ quit_key: int = DEFAULT_QUIT_KEY
 fullscreen: bool = False
 has_init: bool = False
 _drop_file: str = ""
+_unsafe_core = core
 
 
 @property  # type: ignore
@@ -533,7 +534,8 @@ def init(
     quit_key: int = DEFAULT_QUIT_KEY,
     fullscreen: bool = False,
 ) -> None:
-    global has_init
+    global has_init, core
+
     _image_bank.clear()
     _tilemap_bank.clear()
     _sound_bank.clear()
@@ -549,7 +551,7 @@ def init(
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    core.init(
+    _unsafe_core.init(
         int(width),
         int(height),
         caption.encode("utf-8"),
@@ -559,6 +561,8 @@ def init(
         int(quit_key),
         int(fullscreen),
     )
+
+    core = _unsafe_core
     has_init = True
 
 
@@ -860,6 +864,18 @@ class _CListInterface(MutableSequence):  # type: ignore
         lst = self._data_to_list()
         lst.insert(ii, val)
         self._list_to_data(lst)
+
+
+#
+# Protect core model from non-initialized access
+#
+class _NonInitialized:
+    def __getattr__(self, attr):
+        msg = "run pyxel.init(width, height) before executing this command"
+        raise RuntimeError(msg)
+
+
+core = _NonInitialized()
 
 
 #

--- a/pyxel/__init__.py
+++ b/pyxel/__init__.py
@@ -490,6 +490,13 @@ class Music:
 width: int = 0
 height: int = 0
 frame_count: int = 0
+caption: str = DEFAULT_CAPTION
+scale: int = DEFAULT_SCALE
+palette: List[int] = DEFAULT_PALETTE
+fps: int = DEFAULT_FPS
+quit_key: int = DEFAULT_QUIT_KEY
+fullscreen: bool = False
+has_init: bool = False
 _drop_file: str = ""
 
 
@@ -526,10 +533,19 @@ def init(
     quit_key: int = DEFAULT_QUIT_KEY,
     fullscreen: bool = False,
 ) -> None:
+    global has_init
     _image_bank.clear()
     _tilemap_bank.clear()
     _sound_bank.clear()
     _music_bank.clear()
+
+    globs = globals()
+    globs["caption"] = caption
+    globs["scale"] = scale
+    globs["palette"] = palette
+    globs["fps"] = fps
+    globs["quit_key"] = quit_key
+    globs["fullscreen"] = fullscreen
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
@@ -543,6 +559,7 @@ def init(
         int(quit_key),
         int(fullscreen),
     )
+    has_init = True
 
 
 def run(update: Callable[[], None], draw: Callable[[], None]) -> None:


### PR DESCRIPTION
This PR has two simple commits

1. Save init parameters such as fps, fullscreen, etc to the pyxel module (issue #266).
2. Now non-initialized access to pyxel.<attr> and calls to pyxel.<func> raise exceptions instead of crashing the application.