### PR TITLE
Update __init__.py to fix deprecation warning

### DIFF
--- a/pyxel/__init__.py
+++ b/pyxel/__init__.py
@@ -3,7 +3,7 @@ import os
 import signal
 import sys
 import traceback
-from collections import MutableSequence
+from collections.abc import MutableSequence
 from ctypes import CFUNCTYPE, c_char_p, c_int32, cast, create_string_buffer
 from typing import Any, Callable, Dict, List, Optional
 


### PR DESCRIPTION
Since Python 3.3 using base classes straight from collections instead of collections.abc is deprecated ([source](https://docs.python.org/3/whatsnew/3.3.html#collections)) and will stop working in Python 3.10

This is a quick edit to fix that