### PR TITLE
PosixPath support in pyxel.load()

### DIFF
--- a/lib/wrapper/src/resource_wrapper.rs
+++ b/lib/wrapper/src/resource_wrapper.rs
@@ -4,7 +4,7 @@ use crate::instance;
 
 #[pyfunction]
 #[pyo3(text_signature = "(filename, *, image, tilemap, sound, music)")]
-fn load(
+fn load_(
     filename: &str,
     image: Option<bool>,
     tilemap: Option<bool>,
@@ -50,7 +50,7 @@ fn screencast(scale: Option<u32>) {
 }
 
 pub fn add_resource_functions(m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(load, m)?)?;
+    m.add_function(wrap_pyfunction!(load_, m)?)?;
     m.add_function(wrap_pyfunction!(save, m)?)?;
     m.add_function(wrap_pyfunction!(screenshot, m)?)?;
     m.add_function(wrap_pyfunction!(reset_capture, m)?)?;

--- a/pyxel/__init__.py
+++ b/pyxel/__init__.py
@@ -1,6 +1,10 @@
 import platform
+import os
 
 _system = platform.system()
+
+def load(filename, *, image = True, tilemap = True, sound = True, music = True):
+    load_(os.fspath(filename), image, tilemap, sound, music)
 
 if _system == "Darwin":
     from .lib.macos.pyxel_wrapper import *  # type: ignore  # noqa F403


### PR DESCRIPTION
renamed original `pyxel.load` to `pyxel.load_` to run filename through `os.fspath`