### PR TITLE
Some README edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Pyxel is open source and free to use. Let's start making a retro game with Pyxel
     - [Music Class](#music-class)
     - [Advanced APIs](#advanced-apis)
 - [How to Contribute](#how-to-contribute)
+    - [Building Overview](#building-overview)
+    - [Submitting Issues](#submitting-issues)
+    - [Manual Testing](#manual-testing)
+    - [Submitting Pull Requests](#submitting-pull-requests)
 - [Other Information](#other-information)
 - [License](#license)
 - [Sponsors](#recruiting-sponsors)
@@ -585,7 +589,17 @@ If you are familiar with your skills, try to create amazing works with [this](py
 
 ## How to Contribute
 
-### Submitting Issue
+### Building Overview
+
+Pyxel is built primarily using Rust, and installed via Pip. Ensure you have the *nightly* version of Rust installed with `rustup`, or `make` will generate build errors.
+
+The `make clean build` command will not install the build, so ensure you run ``pip3 install --force-reinstall `ls -rt ./dist/*.whl | tail -n 1` `` followed by `python3 -m unittest discover ./crates/pyxel-extension/tests` to install it.
+
+By default, `make clean test` will build and install Pyxel, and will then run *all* of the tests in the examples directory, so if you do not wish to run some of these examples, you will need to comment them out of the Makefile.
+
+For more information and a direct look at the build tasks, check the [Makefile](Makefile) directly.
+
+### Submitting Issues
 
 Use the [Issue Tracker](https://github.com/kitao/pyxel/issues) to submit bug reports and feature/enhancement requests. Before submitting a new issue, ensure that there is no similar open issue.
 
@@ -593,7 +607,7 @@ Use the [Issue Tracker](https://github.com/kitao/pyxel/issues) to submit bug rep
 
 Anyone manually testing the code and reporting bugs or suggestions for enhancements in the [Issue Tracker](https://github.com/kitao/pyxel/issues) are very welcome!
 
-### Submitting Pull Request
+### Submitting Pull Requests
 
 Patches/fixes are accepted in form of pull requests (PRs). Make sure the issue the pull request addresses is open in the Issue Tracker.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,33 @@ Pyxel's specifications and APIs are inspired by [PICO-8](https://www.lexaloffle.
 
 Pyxel is open source and free to use. Let's start making a retro game with Pyxel!
 
+## Contents
+- [Specifications](#specifications)
+- [How to Install](#how-to-install)
+    - [Try Pyxel Examples](#try-pyxel-examples)
+- [How to Use](#how-to-use)
+    - [Create Pyxel Application](#create-pyxel-application)
+    - [Run Pyxel Application](#run-pyxel-application)
+    - [Special Controls](#special-controls)
+    - [How to Create Resources](#how-to-create-resources)
+    - [How to Distribute Applications](#how-to-distribute-applications)
+- [API Reference](#api-reference)
+    - [System](#system)
+    - [Resource](#resource)
+    - [Input](#input)
+    - [Graphics](#graphics)
+    - [Audio](#audio)
+    - [Math](#math)
+    - [Image Class](#image-class)
+    - [Tilemap Class](#tilemap-class)
+    - [Sound Class](#sound-class)
+    - [Music Class](#music-class)
+    - [Advanced APIs](#advanced-apis)
+- [How to Contribute](#how-to-contribute)
+- [Other Information](#other-information)
+- [License](#license)
+- [Sponsors](#recruiting-sponsors)
+
 ## Specifications
 
 - Runs on Windows, Mac, Linux, and web browsers
@@ -210,7 +237,7 @@ Toggle the performance monitor (fps, update time, and draw time)
 - `Alt(Option)+Enter`<br>
 Toggle full screen
 
-### How to Create Resource
+### How to Create Resources
 
 Pyxel Editor can create images and sounds used in a Pyxel application.
 
@@ -268,7 +295,7 @@ Pyxel sounds can also be created in the following method:
 
 Please refer to the API reference for usage of these functions.
 
-### How to Distribute Application
+### How to Distribute Applications
 
 Pyxel supports a dedicated application distribution file format (Pyxel application file) that works across platforms.
 

--- a/README.md
+++ b/README.md
@@ -26,37 +26,6 @@ Pyxel's specifications and APIs are inspired by [PICO-8](https://www.lexaloffle.
 
 Pyxel is open source and free to use. Let's start making a retro game with Pyxel!
 
-## Contents
-- [Specifications](#specifications)
-- [How to Install](#how-to-install)
-    - [Try Pyxel Examples](#try-pyxel-examples)
-- [How to Use](#how-to-use)
-    - [Create Pyxel Application](#create-pyxel-application)
-    - [Run Pyxel Application](#run-pyxel-application)
-    - [Special Controls](#special-controls)
-    - [How to Create Resources](#how-to-create-resources)
-    - [How to Distribute Applications](#how-to-distribute-applications)
-- [API Reference](#api-reference)
-    - [System](#system)
-    - [Resource](#resource)
-    - [Input](#input)
-    - [Graphics](#graphics)
-    - [Audio](#audio)
-    - [Math](#math)
-    - [Image Class](#image-class)
-    - [Tilemap Class](#tilemap-class)
-    - [Sound Class](#sound-class)
-    - [Music Class](#music-class)
-    - [Advanced APIs](#advanced-apis)
-- [How to Contribute](#how-to-contribute)
-    - [Building Overview](#building-overview)
-    - [Submitting Issues](#submitting-issues)
-    - [Manual Testing](#manual-testing)
-    - [Submitting Pull Requests](#submitting-pull-requests)
-- [Other Information](#other-information)
-- [License](#license)
-- [Sponsors](#recruiting-sponsors)
-
 ## Specifications
 
 - Runs on Windows, Mac, Linux, and web browsers

--- a/README.md
+++ b/README.md
@@ -558,16 +558,6 @@ If you are familiar with your skills, try to create amazing works with [this](py
 
 ## How to Contribute
 
-### Building Overview
-
-Pyxel is built primarily using Rust, and installed via Pip. Ensure you have the *nightly* version of Rust installed with `rustup`, or `make` will generate build errors.
-
-The `make clean build` command will not install the build, so ensure you run ``pip3 install --force-reinstall `ls -rt ./dist/*.whl | tail -n 1` `` followed by `python3 -m unittest discover ./crates/pyxel-extension/tests` to install it.
-
-By default, `make clean test` will build and install Pyxel, and will then run *all* of the tests in the examples directory, so if you do not wish to run some of these examples, you will need to comment them out of the Makefile.
-
-For more information and a direct look at the build tasks, check the [Makefile](Makefile) directly.
-
 ### Submitting Issues
 
 Use the [Issue Tracker](https://github.com/kitao/pyxel/issues) to submit bug reports and feature/enhancement requests. Before submitting a new issue, ensure that there is no similar open issue.


### PR DESCRIPTION
A somewhat subjective edit to the main README that I felt would be useful as I was setting up my dev environment.
Changes:

- A table of contents linking to the different sections
- Some typos/grammar things changed (Submitting Issue -> Submitting Issues, etc.)
- A short section about setting up a build environment. I didn't see anything in the README about this already, so when I was first setting up, I skimmed the Makefile and managed to miss the nightly Rust requirement, and that the build task didn't install the Pip package, and was promptly confused by errors for a bit. Explicitly mentioning these in the README could be useful.