### PR TITLE
Remove array-macro dependency

### DIFF
--- a/crates/pyxel-core/Cargo.toml
+++ b/crates/pyxel-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "pyxel-core"
 version = "1.9.8"
 authors = ["Takashi Kitao <takashi.kitao@gmail.com>"]
 edition = "2021"
+rust-version = "1.63"
 description = "Core engine for Pyxel, a retro game engine for Python"
 repository = "https://github.com/kitao/pyxel"
 license = "MIT"
@@ -20,7 +21,6 @@ path = "tests/test_pyxel.rs"
 harness = false
 
 [dependencies]
-array-macro = "2.1"
 gif = "0.12"
 image = "0.24"
 indexmap = "1.9"

--- a/crates/pyxel-core/src/audio.rs
+++ b/crates/pyxel-core/src/audio.rs
@@ -1,4 +1,4 @@
-use array_macro::array;
+use std::array;
 
 use crate::blipbuf::BlipBuf;
 use crate::channel::{Channel, SharedChannel};
@@ -39,9 +39,9 @@ impl Audio {
     pub fn init() {
         let mut blip_buf = BlipBuf::new(NUM_SAMPLES as usize);
         blip_buf.set_rates(CLOCK_RATE as f64, SAMPLE_RATE as f64);
-        let channels = array![_ => Channel::new(); NUM_CHANNELS as usize];
-        let sounds = array![_ => Sound::new(); NUM_SOUNDS as usize];
-        let musics = array![_ => Music::new(); NUM_MUSICS as usize];
+        let channels = array::from_fn(|_| Channel::new());
+        let sounds = array::from_fn(|_| Sound::new());
+        let musics = array::from_fn(|_| Music::new());
 
         Platform::instance().start_audio(
             SAMPLE_RATE,

--- a/crates/pyxel-core/src/graphics.rs
+++ b/crates/pyxel-core/src/graphics.rs
@@ -1,4 +1,5 @@
-use array_macro::array;
+use std::array;
+
 use parking_lot::Mutex;
 
 use crate::image::{Image, SharedImage};
@@ -26,8 +27,9 @@ impl Graphics {
         let screen = Image::new(crate::width(), crate::height());
         let cursor = Self::new_cursor_image();
         let font = Self::new_font_image();
-        let images = array![_ => Image::new(IMAGE_SIZE, IMAGE_SIZE); NUM_IMAGES as usize];
-        let tilemaps = array![_ => Tilemap::new(TILEMAP_SIZE, TILEMAP_SIZE, images[0].clone()); NUM_TILEMAPS as usize];
+        let images = array::from_fn(|_| Image::new(IMAGE_SIZE, IMAGE_SIZE));
+        let tilemaps =
+            array::from_fn(|_| Tilemap::new(TILEMAP_SIZE, TILEMAP_SIZE, images[0].clone()));
         Self::set_instance(Self {
             screen,
             cursor,

--- a/crates/pyxel-core/src/image.rs
+++ b/crates/pyxel-core/src/image.rs
@@ -1,8 +1,8 @@
+use std::array;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::path::Path;
 
-use array_macro::array;
 use image::imageops::{self, FilterType};
 use image::{Rgb, RgbImage};
 
@@ -34,7 +34,7 @@ impl Image {
     pub fn new(width: u32, height: u32) -> SharedImage {
         new_shared_type!(Self {
             canvas: Canvas::new(width, height),
-            palette: array![i => i as Color; NUM_COLORS as usize],
+            palette: array::from_fn(|i| i as Color),
         })
     }
 


### PR DESCRIPTION
Using `array-macro` isn't really necessary here now that standard library has `array::from_fn`. This makes the codebase somewhat safer as `std` has more people looking into its safety than `array-macro` crate (which pretty much is maintained by just me).