### PR TITLE
use textContent prior to script attribute of pyxel-run tag

### DIFF
--- a/wasm/pyxel.js
+++ b/wasm/pyxel.js
@@ -429,19 +429,31 @@ class PyxelRunElement extends HTMLElement {
     return ["root", "name", "script", "packages", "gamepad"];
   }
 
+  hasLaunchPyxel = false
+
   constructor() {
     super();
+    this.observer = new MutationObserver(() => {
+      if (!this.hasLaunchPyxel) {
+        this.hasLaunchPyxel = true
+        launchPyxel({
+          command: "run",
+          root: this.root,
+          name: this.name,
+          script: this.textContent || this.script,
+          packages: this.packages,
+          gamepad: this.gamepad,
+        });
+      }
+    });
   }
 
   connectedCallback() {
-    launchPyxel({
-      command: "run",
-      root: this.root,
-      name: this.name,
-      script: this.script,
-      packages: this.packages,
-      gamepad: this.gamepad,
-    });
+    this.observer.observe(this, { subtree: true, childList: true, characterData: true });
+  }
+  
+  disconnectedCallback() {
+    this.observer.disconnect();
   }
 
   attributeChangedCallback(name, _oldValue, newValue) {


### PR DESCRIPTION
It's related to https://github.com/kitao/pyxel/issues/458. Because I could not get the textContent in connectedCallback, so I use [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe) to get it, see also https://github.com/WICG/webcomponents/issues/903.