### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ Pyxel application file also can be converted to an executable or an HTML file wi
   Set notes, tones, volumes, and effects with a string. If the tones, volumes, and effects length are shorter than the notes, it is repeated from the beginning.
 
 - `set_notes(notes)`<br>
-  Set the notes with a string made of 'CDEFGAB'+'#-'+'0123' or 'R'. Case-insensitive and whitespace is ignored.<br>
+  Set the notes with a string made of 'CDEFGAB'+'#-'+'01234' or 'R'. Case-insensitive and whitespace is ignored.<br>
   e.g. `pyxel.sound(0).set_notes("G2B-2D3R RF3F3F3")`
 
 - `set_tones(tones)`<br>


### PR DESCRIPTION
After some testing it seems like Pyxel allows octaves up to 4.

For example, I created a sound with notes "c0c1c2c3c4" and I can hear all five different sounds.