### PR TITLE
APP_FILE_EXTENSION constant reference error

### DIFF
--- a/python/pyxel/cli.py
+++ b/python/pyxel/cli.py
@@ -282,7 +282,7 @@ def create_executable_from_pyxel_app(pyxel_app_file):
     with open(startup_script_file, "w") as f:
         f.write(
             "import os, pyxel.cli; pyxel.cli.play_pyxel_app("
-            f"os.path.join(os.path.dirname(__file__), '{pyxel_app_name}.{pyxel.APP_FILE_EXTENSION}'))"
+            f"os.path.join(os.path.dirname(__file__), '{pyxel_app_name}{pyxel.APP_FILE_EXTENSION}'))"
         )
     cp = subprocess.run("pyinstaller -h", capture_output=True, shell=True)
     if cp.returncode != 0:
@@ -319,7 +319,7 @@ def create_html_from_pyxel_app(pyxel_app_file):
             '<script src="https://cdn.jsdelivr.net/gh/kitao/pyxel/wasm/pyxel.js">'
             "</script>\n"
             "<script>\n"
-            f'launchPyxel({{ command: "play", name: "{pyxel_app_name}.{pyxel.APP_FILE_EXTENSION}", '
+            f'launchPyxel({{ command: "play", name: "{pyxel_app_name}{pyxel.APP_FILE_EXTENSION}", '
             f'gamepad: "enabled", base64: "{base64_string}" }});\n'
             "</script>\n"
         )


### PR DESCRIPTION
When `app2exe` are executed, **startup_script_file** is generated and the running pyxapp file name is written.The constant **APP_FILE_EXTENSION** is called here as the file extension (**.pyxapp**), but there is an extra dot symbol, which will result in a file name like xxx`..`pyxapp, causing the exe file fails to be run,because the corresponding filename file could not be found.
The same reference error when executing `app2html`, but running the html will generate the corresponding filename file through the **_copyFileFromBase64** method in **pyxel.js**, although there will be no runtime error, it is better to modify together.
Current versions greater than 2.0.10 have the above problem.