### PR TITLE
get metadata in utf8

### DIFF
--- a/python/pyxel/cli.py
+++ b/python/pyxel/cli.py
@@ -175,7 +175,7 @@ def _get_metadata_comment(startup_script_file):
     METADATA_FIELDS = ["title", "author", "desc", "site", "license", "version"]
     metadata = {}
     metadata_pattern = re.compile(r"#\s*(.+?)\s*:\s*(.+)")
-    with open(startup_script_file, "r") as f:
+    with open(startup_script_file, "r",encoding="utf8") as f:
         for line in f:
             match = metadata_pattern.match(line)
             if match:


### PR DESCRIPTION
When getting metadata in startup_script_file, specify utf8 encoding to be compatible with other characters such as Chinese