### PR TITLE
Removed python-source value to work around issue in maturin 1.7.1+

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,7 +35,6 @@ pyxel = "pyxel.cli:cli"
 [tool.maturin]
 manifest-path = "../rust/pyxel-wrapper/Cargo.toml"
 module-name = "pyxel.pyxel_wrapper"
-python-source = "../python"
 
 [tool.maturin.target."x86_64-apple-darwin"]
 macos-deployment-target = "10.12"


### PR DESCRIPTION
The config references the directory it's in, so we can just omit it.