### PR TITLE
fix: stack overflow in `fill`

### DIFF
--- a/rust/pyxel-engine/src/sound.rs
+++ b/rust/pyxel-engine/src/sound.rs
@@ -169,7 +169,9 @@ mod tests {
     #[test]
     fn test_sound_set() {
         let sound = Sound::new();
-        sound.lock().set("c0d-0d0d#0", "tspn", "0123", "nsvf", 123);
+        sound
+            .lock()
+            .set("c0d-0d0d#0", "tspn", "012345", "nsvfhq", 123);
         assert_eq!(&sound.lock().notes, &vec![0, 1, 2, 3]);
         assert_eq!(
             &sound.lock().tones,


### PR DESCRIPTION
filling a large area (such as the entire screen starting from one of the corner pixels) can result in very deeply nested recursion in `fill_rec`, manifesting as a crash when calling `fill(...)` from python.

my approach to fixing this is to use a stack of coordinates to visit in a loop rather than recursing. this stack is initialised with a worst-case capacity of every pixel in the clipping region to avoid reallocs.

i've added a test that does a worst-case fill on a large canvas to validate the solution.

unrelated: while working on this i noticed that `test_sound_set` was failing. the `sound` instance in the test was missing the last two volumes & effects that were being asserted, so i added them to the `.set(...)` call. that change is in a separate commit from the `fill_rec` fix.

let me know what you think. thanks!