### PR TITLE
pyxel app2exe verb has problem with white spaces in its sole argument

### DIFF
--- a/python/pyxel/cli.py
+++ b/python/pyxel/cli.py
@@ -436,5 +436,3 @@ def copy_pyxel_examples():
         os.makedirs(os.path.dirname(dst_file), exist_ok=True)
         shutil.copyfile(src_file, dst_file)
         print(f"copied '{dst_file}'")
-
-cli()


### PR DESCRIPTION
fixes #629
This comes from the command line construction for pyinstaller.
Moreover, a problem exists under the same conditions and the same function for the path of the Python interpreter.
Modules that do not adhere to the principle of having no spaces in their names also potentially have this issue here. This contribution has encapsulated the paths in double quotes that are themselves escaped in their literals.