### PR TITLE
feat: support newlines in text with custom font

### DIFF
--- a/rust/pyxel-engine/src/font.rs
+++ b/rust/pyxel-engine/src/font.rs
@@ -126,8 +126,15 @@ impl Font {
         text: &str,
         color: Color,
     ) {
+        let start_x = x;
         let mut x = x;
+        let mut y = y;
         for c in text.chars() {
+            if c == '\n' {
+                x = start_x;
+                y += self.font_bounding_box.height;
+                continue;
+            }
             if let Some(glyph) = self.glyphs.get(&(c as i32)) {
                 self.draw_glyph(canvas, x, y, glyph, color);
                 x += glyph.dwidth;


### PR DESCRIPTION
resolves #643

implementation based on [`Image::text`](https://github.com/kitao/pyxel/blob/4b38f5f1c706c54495220d0bd4a3ddc903b2e845/rust/pyxel-engine/src/image.rs#L589-L634).

tested with a few different fonts, results below.

<details>
<summary>text with newlines before</summary>
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/f6e75a07-0ffb-4347-810b-524f4d6b3d27" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/9c6fc211-bcbf-4be2-9358-4960a7d31225" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/77984372-8d30-4701-a7f2-5fead6e1b65b" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/41cdef5f-d9ac-4162-8591-0b570c42b12d" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/c37c41d2-5801-42ac-8ec7-ca49bca32576" />
</details>

<details>
<summary>text with newlines after</summary>
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/490b60ef-d9a5-4d16-afca-da48e96148ec" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/a5cbf24c-43d9-4ad3-a836-732e2aefbc8c" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/be34264e-dba6-4228-803b-53a2da25da56" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/5d296d17-3a94-42ef-9aa8-87c7a53e1259" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/a2688578-a73e-4aff-8a25-f2fcc84f5a9a" />
</details>

<details>
<summary>test script used to generate the above images</summary>

```python
from pathlib import Path
import pyxel

pyxel.init(256, 256)
img = pyxel.Image(pyxel.width, pyxel.height)


def render(font_path: Path | None = None) -> None:
    if font_path:
        font = pyxel.Font(str(font_path))
        font_name = font_path.name
    else:
        font = None
        font_name = "default"

    img.cls(0)
    img.text(
        4,
        40,
        (
            "the aim of art\n"
            "is to represent\n"
            "not the outward appearance\n"
            "of things,\n"
            "\n"
            "but their inward significance."
        ),
        15,
        font=font,
    )
    img.text(
        (pyxel.width - (len(font_name) + 4) * 4) / 2,
        pyxel.height - 8,
        f"<{font_name}>",
        col=14,
    )
    p = Path("text-results")
    p.mkdir(exist_ok=True)
    img.save(str(p / font_name), 2)


render()
for font in Path("text-fonts").glob("*"):
    render(font)
```

</details>