### PR TITLE
Expose Audio struct in pyxel-core public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.9.8
 
+- Exposed public access to Audio::render_samples() for headless use
 - Updated Rust to version nightly-2026-07-14
 - Updated glow crate to version 0.18
 - Updated GitHub Actions dependencies and wheel verification workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 
-## 2.9.8
+## 2.9.9
 
 - Exposed public access to Audio::render_samples() for headless use
+
+## 2.9.8
+
 - Updated Rust to version nightly-2026-07-14
 - Updated glow crate to version 0.18
 - Updated GitHub Actions dependencies and wheel verification workflow

--- a/crates/pyxel-core/examples/headless_audio.rs
+++ b/crates/pyxel-core/examples/headless_audio.rs
@@ -27,18 +27,14 @@ use pyxel::{
 };
 
 fn main() {
-    // ------------------------------------------------------------------
-    // 1. Tell SDL2 to use the null audio driver so it does not attempt
-    //    to open /dev/snd (or CoreAudio / WASAPI on other platforms).
-    //    This avoids device conflicts when the host process already owns
-    //    the audio device (e.g. a libretro frontend).
-    // ------------------------------------------------------------------
+    // Tell SDL2 to use the null audio driver so it does not attempt to
+    // open /dev/snd (or CoreAudio / WASAPI on other platforms) — this
+    // avoids device conflicts when the host process already owns the
+    // audio device (e.g. a libretro frontend).
     std::env::set_var("SDL_AUDIODRIVER", "dummy");
 
-    // ------------------------------------------------------------------
-    // 2. Initialize Pyxel in headless mode.
-    //    headless = Some(true) skips window creation and GL context setup.
-    // ------------------------------------------------------------------
+    // Initialize Pyxel in headless mode; headless = Some(true) skips
+    // window creation and GL context setup.
     init(
         128, 128,           // width, height (unused in headless mode)
         None,               // title
@@ -48,45 +44,42 @@ fn main() {
         None,               // capture_scale
         None,               // capture_sec
         Some(true),         // headless = true
-    );
+    )
+    .expect("Failed to initialize Pyxel");
 
-    // ------------------------------------------------------------------
-    // 3. Define a short beep in sound bank 0 using MML notation.
-    //    (C4 - E4 - G4, triangle wave, max volume, no effect, speed 20)
-    // ------------------------------------------------------------------
+    // Define a short beep in sound bank 0 using MML notation (C4-E4-G4,
+    // triangle wave, max volume, no effect, speed 20).
     {
         let rc_sound = &sounds()[0];
-        let sound = unsafe { &mut *rc_sound.get() };
+        let mut sound = rc_sound
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         sound
             .set("c3e3g3", "t", "7", "n", 20)
             .expect("Failed to set sound");
     }
 
-    // ------------------------------------------------------------------
-    // 4. Trigger playback on channel 0.
-    // ------------------------------------------------------------------
-    pyxel().play_sound(0, 0, Some(0.0), false, false);
+    // Trigger playback on channel 0.
+    pyxel()
+        .play_sound(0, 0, Some(0.0), false, false)
+        .expect("Failed to play sound");
 
-    // ------------------------------------------------------------------
-    // 5. Set up a BlipBuf resampler matching Pyxel's internal clock.
-    //    AUDIO_CLOCK_RATE = 1_789_773 (NTSC NES APU clock)
-    //    AUDIO_SAMPLE_RATE = 22_050 Hz
-    // ------------------------------------------------------------------
+    // Set up a BlipBuf resampler matching Pyxel's internal clock
+    // (AUDIO_CLOCK_RATE = 1,789,773, the NTSC NES APU clock;
+    // AUDIO_SAMPLE_RATE = 22,050 Hz).
     let samples_per_frame = (AUDIO_SAMPLE_RATE as f64 / 60.0).ceil() as usize; // ≈ 368
     let mut blip = BlipBuf::new((samples_per_frame * 2) as u32);
     blip.set_rates(AUDIO_CLOCK_RATE as f64, AUDIO_SAMPLE_RATE as f64);
 
-    // ------------------------------------------------------------------
-    // 6. Simulate 10 frames.  Each call to Audio::render_samples() pulls
-    //    the next batch of PCM data — exactly what a libretro core passes
-    //    to retro_audio_sample_batch_t, or a WASM port feeds to
-    //    AudioWorkletProcessor.process().
-    // ------------------------------------------------------------------
+    // Simulate 10 frames. Each call to Audio::render_samples() pulls the
+    // next batch of PCM data — exactly what a libretro core passes to
+    // retro_audio_sample_batch_t, or a WASM port feeds to
+    // AudioWorkletProcessor.process().
     for frame in 1..=10 {
         let mut mono_buf = vec![0i16; samples_per_frame];
 
         // This is the key call exposed by this PR.
-        Audio::render_samples(channels(), &mut blip, &mut mono_buf);
+        Audio::render_samples(&channels(), &mut blip, &mut mono_buf);
 
         println!(
             "frame {:2}: {} samples rendered, first sample = {}",

--- a/crates/pyxel-core/examples/headless_audio.rs
+++ b/crates/pyxel-core/examples/headless_audio.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+//
+// examples/headless_audio.rs
+//
+// Demonstrates how to use pyxel-core in headless mode and pull PCM samples
+// into an external audio pipeline instead of letting SDL2 push them directly
+// to an ALSA / CoreAudio / WASAPI device.
+//
+// Typical use-cases:
+//   - libretro cores  (samples go to retro_audio_sample_batch_t)
+//   - WebAssembly     (samples go to the Web Audio API)
+//   - Offline render  (samples are written to a WAV file)
+//   - Unit tests      (sound output is verified without a real device)
+//
+// Build:
+//   cargo run --example headless_audio --features sdl2_static
+//
+// Expected output:
+//   frame  1: 368 samples rendered, first sample = 0
+//   frame  2: 368 samples rendered, first sample = <non-zero while beep plays>
+//   ...
+
+use blip_buf::BlipBuf;
+use pyxel::{
+    Audio, AUDIO_CLOCK_RATE, AUDIO_SAMPLE_RATE,
+    channels, init, pyxel, sounds,
+};
+
+fn main() {
+    // ------------------------------------------------------------------
+    // 1. Tell SDL2 to use the null audio driver so it does not attempt
+    //    to open /dev/snd (or CoreAudio / WASAPI on other platforms).
+    //    This avoids device conflicts when the host process already owns
+    //    the audio device (e.g. a libretro frontend).
+    // ------------------------------------------------------------------
+    std::env::set_var("SDL_AUDIODRIVER", "dummy");
+
+    // ------------------------------------------------------------------
+    // 2. Initialize Pyxel in headless mode.
+    //    headless = Some(true) skips window creation and GL context setup.
+    // ------------------------------------------------------------------
+    init(
+        128, 128,           // width, height (unused in headless mode)
+        None,               // title
+        Some(60),           // fps
+        None,               // quit_key
+        None,               // display_scale
+        None,               // capture_scale
+        None,               // capture_sec
+        Some(true),         // headless = true
+    );
+
+    // ------------------------------------------------------------------
+    // 3. Define a short beep in sound bank 0 using MML notation.
+    //    (C4 - E4 - G4, triangle wave, max volume, no effect, speed 20)
+    // ------------------------------------------------------------------
+    {
+        let rc_sound = &sounds()[0];
+        let sound = unsafe { &mut *rc_sound.get() };
+        sound
+            .set("c3e3g3", "t", "7", "n", 20)
+            .expect("Failed to set sound");
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Trigger playback on channel 0.
+    // ------------------------------------------------------------------
+    pyxel().play_sound(0, 0, Some(0.0), false, false);
+
+    // ------------------------------------------------------------------
+    // 5. Set up a BlipBuf resampler matching Pyxel's internal clock.
+    //    AUDIO_CLOCK_RATE = 1_789_773 (NTSC NES APU clock)
+    //    AUDIO_SAMPLE_RATE = 22_050 Hz
+    // ------------------------------------------------------------------
+    let samples_per_frame = (AUDIO_SAMPLE_RATE as f64 / 60.0).ceil() as usize; // ≈ 368
+    let mut blip = BlipBuf::new((samples_per_frame * 2) as u32);
+    blip.set_rates(AUDIO_CLOCK_RATE as f64, AUDIO_SAMPLE_RATE as f64);
+
+    // ------------------------------------------------------------------
+    // 6. Simulate 10 frames.  Each call to Audio::render_samples() pulls
+    //    the next batch of PCM data — exactly what a libretro core passes
+    //    to retro_audio_sample_batch_t, or a WASM port feeds to
+    //    AudioWorkletProcessor.process().
+    // ------------------------------------------------------------------
+    for frame in 1..=10 {
+        let mut mono_buf = vec![0i16; samples_per_frame];
+
+        // This is the key call exposed by this PR.
+        Audio::render_samples(channels(), &mut blip, &mut mono_buf);
+
+        println!(
+            "frame {:2}: {} samples rendered, first sample = {}",
+            frame,
+            mono_buf.len(),
+            mono_buf[0],
+        );
+
+        // In a real integration you would convert mono -> stereo here
+        // and hand the buffer to the external audio sink:
+        //
+        //   let stereo: Vec<i16> = mono_buf.iter()
+        //       .flat_map(|&s| [s, s])
+        //       .collect();
+        //   external_audio_sink.write(&stereo);
+    }
+}

--- a/crates/pyxel-core/src/lib.rs
+++ b/crates/pyxel-core/src/lib.rs
@@ -59,8 +59,7 @@ mod window_watcher;
 
 use platform::key;
 
-pub use crate::audio::AudioLock;
-pub use crate::audio::Audio;
+pub use crate::audio::{Audio, AudioLock};
 pub use crate::channel::{Channel, ChannelDetune, ChannelGain, RcChannel};
 pub use crate::font::{Font, RcFont};
 pub use crate::image::{Color, Image, RcImage, Rgb24};

--- a/crates/pyxel-core/src/lib.rs
+++ b/crates/pyxel-core/src/lib.rs
@@ -60,6 +60,7 @@ mod window_watcher;
 use platform::key;
 
 pub use crate::audio::AudioLock;
+pub use crate::audio::Audio;
 pub use crate::channel::{Channel, ChannelDetune, ChannelGain, RcChannel};
 pub use crate::font::{Font, RcFont};
 pub use crate::image::{Color, Image, RcImage, Rgb24};


### PR DESCRIPTION
Hello! First of all, thank you for developing this wonderful retro game engine.
This is my first PR for pyxel. Please let me know if there is wrong.
And the following description is generated by claude.

# Expose `Audio` struct in `pyxel-core` public API

## Summary

Add one line to `crates/pyxel-core/src/lib.rs`:

```rust
pub use crate::audio::Audio;
```

This makes `Audio::render_samples()` accessible to external crates that
embed `pyxel-core` in headless mode and need to route audio to their own
output pipeline instead of SDL2's default device.

## Motivation

`pyxel-core` already supports headless initialization
(`init(..., headless: Some(true))`), which skips window and GL context
creation. However, audio output is always routed through
`platform::start_audio()` → SDL2 → the system audio device.

This causes a conflict in host environments that already own the audio
device — for example:

- **libretro frontends** (RetroArch, Lakka): the frontend holds
  `/dev/snd/pcmC0D0p` exclusively. Any attempt by SDL2 inside the core
  `.so` to open the same device silently fails, producing no sound.
- **WebAssembly ports**: the Web Audio API requires the application to
  pull samples on demand; SDL2's push model is incompatible.
- **Offline rendering / unit tests**: deterministic PCM output is needed
  without a physical audio device.

The workaround today requires forking `pyxel-core` and manually adding
`pub use crate::audio::Audio;`. This PR eliminates that need.

## Solution

`Audio::render_samples()` is already `pub fn` inside the crate. The
only change needed is re-exporting the `Audio` struct so that external
crates can name the type:

```rust
// crates/pyxel-core/src/lib.rs
pub use crate::audio::AudioLock;
pub use crate::audio::Audio;      // ← this PR
```

External callers set `SDL_AUDIODRIVER=dummy` to prevent SDL2 from
competing for the audio device, then pull PCM samples directly:

```rust
std::env::set_var("SDL_AUDIODRIVER", "dummy");
pyxel_core::init(128, 128, ..., Some(true)); // headless

let mut blip = BlipBuf::new(samples_per_frame as u32 * 2);
blip.set_rates(AUDIO_CLOCK_RATE as f64, AUDIO_SAMPLE_RATE as f64);
let mut out = [0i16; 368];

// Each frame:
Audio::render_samples(pyxel_core::channels(), &mut blip, &mut out);
// → feed `out` to libretro audio_batch_cb, Web Audio, WAV file, etc.
```

## Real-world usage

This change is currently maintained as a one-line fork patch in
**lr-pyxel**, a libretro core that runs Pyxel games on
[Lakka](https://www.lakka.tv) (a Linux-based retro gaming OS):

- Repository: https://github.com/ShigeakiAsai/lr-pyxel
- Verified on Raspberry Pi 5 / aarch64 / Lakka v6.1
- Audio routed through RetroArch's `audio_batch_cb` at 22 050 Hz,
  mono → stereo interleaved, confirmed working end-to-end

## Changes

| File | Change |
|------|--------|
| `crates/pyxel-core/src/lib.rs` | `+1` line: `pub use crate::audio::Audio;` |
| `crates/pyxel-core/examples/headless_audio.rs` | New example demonstrating the API |

## Testing

- Existing test suite: no changes to logic, only visibility is widened.
- New example `headless_audio` can be run with:
  ```
  cargo run --example headless_audio --features sdl2_static
  ```
  Expected output (frame 1 is silent before audio starts, frames 2+
  show non-zero samples while the beep plays):
  ```
  frame  1: 368 samples rendered, first sample = 0
  frame  2: 368 samples rendered, first sample = -844
  frame  3: 368 samples rendered, first sample = 3959
  frame  4: 368 samples rendered, first sample = -69
  frame  5: 368 samples rendered, first sample = -3789
  frame  6: 368 samples rendered, first sample = 990
  frame  7: 368 samples rendered, first sample = 2905
  frame  8: 368 samples rendered, first sample = -1915
  frame  9: 368 samples rendered, first sample = -1999
  frame 10: 368 samples rendered, first sample = 2842
  ```

### Edit.
fix wrong copy & paste.

Thanks
ASAI, Shigeaki