### PR TITLE
Audio::start() runs unconditionally in init(), even when headless=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 
-## 2.9.8
+## 2.9.9
 
 - Added opt-in Cargo feature to skip Audio::start() in headless mode
+
+## 2.9.8
+
 - Updated Rust to version nightly-2026-07-14
 - Updated glow crate to version 0.18
 - Updated GitHub Actions dependencies and wheel verification workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.9.8
 
+- Added opt-in Cargo feature to skip Audio::start() in headless mode
 - Updated Rust to version nightly-2026-07-14
 - Updated glow crate to version 0.18
 - Updated GitHub Actions dependencies and wheel verification workflow

--- a/crates/pyxel-core/Cargo.toml
+++ b/crates/pyxel-core/Cargo.toml
@@ -44,3 +44,4 @@ tar = "0.4"
 [features]
 sdl2_dynamic = []
 sdl2_static = []
+no_headless_audio = []

--- a/crates/pyxel-core/Cargo.toml
+++ b/crates/pyxel-core/Cargo.toml
@@ -42,6 +42,6 @@ flate2 = "1.0"
 tar = "0.4"
 
 [features]
+no_headless_audio = []
 sdl2_dynamic = []
 sdl2_static = []
-no_headless_audio = []

--- a/crates/pyxel-core/src/audio.rs
+++ b/crates/pyxel-core/src/audio.rs
@@ -60,7 +60,35 @@ impl AudioStreamRenderer {
 // Audio output
 
 impl Audio {
+    // Default (feature disabled): unchanged from v2.8.5 — always
+    // starts real SDL2 audio output, headless or not, so a headless
+    // script that wants to hear real audio through SDL2 still gets it.
+    #[cfg(not(feature = "no_headless_audio"))]
     pub fn start() {
+        let mut stream_renderer = AudioStreamRenderer::new();
+
+        platform::start_audio(
+            AUDIO_SAMPLE_RATE,
+            AUDIO_BUFFER_SAMPLES,
+            move |out: &mut [i16]| {
+                stream_renderer.render(out);
+            },
+        );
+    }
+
+    // Opt-in only (see `no_headless_audio` in Cargo.toml): crates that
+    // drive render_samples() externally themselves (see
+    // examples/headless_audio.rs) can ask not to also start this SDL2
+    // callback thread, which would otherwise race with their own
+    // manual calls on the same channel/voice state — this was
+    // observed in practice as roughly-doubled playback speed and
+    // audio noise/distortion when both ran at once.
+    #[cfg(feature = "no_headless_audio")]
+    pub fn start() {
+        if platform::is_headless() {
+            return;
+        }
+
         let mut stream_renderer = AudioStreamRenderer::new();
 
         platform::start_audio(

--- a/crates/pyxel-core/src/platform/facade.rs
+++ b/crates/pyxel-core/src/platform/facade.rs
@@ -33,7 +33,7 @@ fn with_platform_mut<T>(f: impl FnOnce(&mut Platform) -> T) -> T {
     })
 }
 
-fn is_headless() -> bool {
+pub fn is_headless() -> bool {
     HEADLESS.load(Ordering::Relaxed)
 }
 

--- a/crates/pyxel-core/src/platform/mod.rs
+++ b/crates/pyxel-core/src/platform/mod.rs
@@ -9,9 +9,9 @@ pub use event::Event;
 #[cfg(not(target_os = "emscripten"))]
 pub use facade::close_audio;
 pub use facade::{
-    display_size, export_browser_file, gl_profile, init, init_window, is_fullscreen,
-    is_headless, is_sigint_received, lock_audio, pause_audio, poll_events, quit, run_frame_loop,
-    set_fullscreen, set_mouse_pos, set_mouse_visible, set_window_icon, set_window_pos,
-    set_window_size, set_window_title, start_audio, step_frame, ticks, unlock_audio, window_pos,
-    window_size, with_gl_context, GlProfile,
+    display_size, export_browser_file, gl_profile, init, init_window, is_fullscreen, is_headless,
+    is_sigint_received, lock_audio, pause_audio, poll_events, quit, run_frame_loop, set_fullscreen,
+    set_mouse_pos, set_mouse_visible, set_window_icon, set_window_pos, set_window_size,
+    set_window_title, start_audio, step_frame, ticks, unlock_audio, window_pos, window_size,
+    with_gl_context, GlProfile,
 };

--- a/crates/pyxel-core/src/platform/mod.rs
+++ b/crates/pyxel-core/src/platform/mod.rs
@@ -8,8 +8,10 @@ mod sdl2;
 pub use event::Event;
 #[cfg(not(target_os = "emscripten"))]
 pub use facade::close_audio;
+#[cfg(feature = "no_headless_audio")]
+pub use facade::is_headless;
 pub use facade::{
-    display_size, export_browser_file, gl_profile, init, init_window, is_fullscreen, is_headless,
+    display_size, export_browser_file, gl_profile, init, init_window, is_fullscreen,
     is_sigint_received, lock_audio, pause_audio, poll_events, quit, run_frame_loop, set_fullscreen,
     set_mouse_pos, set_mouse_visible, set_window_icon, set_window_pos, set_window_size,
     set_window_title, start_audio, step_frame, ticks, unlock_audio, window_pos, window_size,

--- a/crates/pyxel-core/src/platform/mod.rs
+++ b/crates/pyxel-core/src/platform/mod.rs
@@ -10,8 +10,8 @@ pub use event::Event;
 pub use facade::close_audio;
 pub use facade::{
     display_size, export_browser_file, gl_profile, init, init_window, is_fullscreen,
-    is_sigint_received, lock_audio, pause_audio, poll_events, quit, run_frame_loop, set_fullscreen,
-    set_mouse_pos, set_mouse_visible, set_window_icon, set_window_pos, set_window_size,
-    set_window_title, start_audio, step_frame, ticks, unlock_audio, window_pos, window_size,
-    with_gl_context, GlProfile,
+    is_headless, is_sigint_received, lock_audio, pause_audio, poll_events, quit, run_frame_loop,
+    set_fullscreen, set_mouse_pos, set_mouse_visible, set_window_icon, set_window_pos,
+    set_window_size, set_window_title, start_audio, step_frame, ticks, unlock_audio, window_pos,
+    window_size, with_gl_context, GlProfile,
 };

--- a/crates/pyxel-core/src/pyxel.rs
+++ b/crates/pyxel-core/src/pyxel.rs
@@ -256,6 +256,14 @@ pub fn init(
         graphics,
     });
 
+    // Audio::start() looks unconditional here even in headless mode —
+    // that's intentional. Default behavior matches v2.8.5's design
+    // (a headless script still gets real audio via SDL2). See
+    // audio.rs's own #[cfg(feature = "no_headless_audio")]-gated
+    // Audio::start() implementations for the opt-in exception, used
+    // by embedders that drive render_samples() externally themselves
+    // (e.g. a libretro core) and don't want this SDL2 callback thread
+    // racing their own manual calls.
     Audio::start();
     if !headless {
         pyxel().update_screen_params();

--- a/crates/pyxel-core/src/pyxel.rs
+++ b/crates/pyxel-core/src/pyxel.rs
@@ -257,13 +257,8 @@ pub fn init(
     });
 
     // Audio::start() looks unconditional here even in headless mode —
-    // that's intentional. Default behavior matches v2.8.5's design
-    // (a headless script still gets real audio via SDL2). See
-    // audio.rs's own #[cfg(feature = "no_headless_audio")]-gated
-    // Audio::start() implementations for the opt-in exception, used
-    // by embedders that drive render_samples() externally themselves
-    // (e.g. a libretro core) and don't want this SDL2 callback thread
-    // racing their own manual calls.
+    // that's intentional. See audio.rs's own #[cfg(feature =
+    // "no_headless_audio")]-gated Audio::start() implementations for why.
     Audio::start();
     if !headless {
         pyxel().update_screen_params();

--- a/crates/pyxel-core/src/pyxel.rs
+++ b/crates/pyxel-core/src/pyxel.rs
@@ -256,8 +256,8 @@ pub fn init(
         graphics,
     });
 
+    Audio::start();
     if !headless {
-        Audio::start();
         pyxel().update_screen_params();
         pyxel()
             .set_icon(&ICON_DATA, ICON_SCALE, ICON_COLKEY)

--- a/crates/pyxel-core/src/pyxel.rs
+++ b/crates/pyxel-core/src/pyxel.rs
@@ -256,8 +256,8 @@ pub fn init(
         graphics,
     });
 
-    Audio::start();
     if !headless {
+        Audio::start();
         pyxel().update_screen_params();
         pyxel()
             .set_icon(&ICON_DATA, ICON_SCALE, ICON_COLKEY)

--- a/docs/superpowers/specs/2026-07-14-audio-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-14-audio-reliability-design.md
@@ -1,0 +1,57 @@
+# Audio Reliability Design
+
+## Goal
+
+Remove silent or delayed audio edge cases without adding avoidable work to the
+per-sample synthesis path. Preserve the current public behavior for valid input
+and add deterministic regression coverage for every corrected boundary.
+
+## Timing Model
+
+Voice and channel note durations use 64-bit audio clocks end to end. Rendering
+continues to process bounded 32-bit chunks, but no duration is narrowed before a
+chunk is selected. Additions at interpolation boundaries use saturating
+arithmetic so a valid long note cannot wrap to a short or silent note.
+
+PCM and synthesized playback share the same output timeline. Rendering splits a
+bounded output step at the first channel mode transition, mixes only the samples
+consumed in that span, then reevaluates channel modes. This removes the current
+step-sized PCM-to-synth delay while retaining block processing away from a
+transition.
+
+## Duration and Seeking
+
+Seconds supplied to playback must be finite and non-negative before conversion
+to audio clocks. Invalid values return the same parameter-shaped `ValueError`
+from the global and channel Python APIs. Seeking remains chunked and must either
+consume clocks or terminate, preventing an unbounded loop.
+
+MML duration calculation evaluates a repeat body as a duration and tempo-state
+transition. A finite repeat is fast-forwarded with checked arithmetic instead of
+executing each iteration. Nested repeats use the same evaluator, and an
+unrepresentable duration reports no finite total rather than hanging.
+
+## Saving and Errors
+
+A positive save duration that rounds to zero output samples is rejected before
+file creation. `Sound.save` and `Music.save` use the same message. Invalid speed
+values from `Sound.set` and the speed property use the same `ValueError` family.
+
+## Tests
+
+Rust unit tests cover long note duration, deterministic long seeks, exact mode
+transition timing, and large finite repeat evaluation. Python tests cover public
+exception types and messages, non-finite playback positions, and zero-sample
+save rejection. Render references remain the audible regression layer.
+
+The Python long-seek test does not assert a single immediate `play_pos` value,
+because the audio thread may consume one buffer after playback starts. Exact
+seek arithmetic is asserted in the deterministic Rust layer instead.
+
+## Policy Review
+
+The complete uncommitted audio diff is reviewed against
+`docs/coding-policy.md`, including hot-path cost, sibling wrapper structure,
+error-message families, comment ownership and historical wording, deterministic
+tests, and release-note accuracy. Formatting, native and WebAssembly lint, and
+the full test suite are required completion gates.


### PR DESCRIPTION
> **Note**: This description was revised after discovering the original
> implementation conflicted with v2.8.5's "Enabled audio playback in
> headless mode" design (see the discussion in the comments below for
> how that was found). The description below reflects the current
> implementation, rebased onto the latest `upstream/main`.

## Problem

When pyxel-core is embedded inside a host that already owns audio
output and drives `Audio::render_samples()` itself — e.g. a libretro
core passing samples to `retro_audio_sample_batch_t`, or a WASM port
feeding the Web Audio API (see `examples/headless_audio.rs`) —
`Audio::start()`'s own SDL2 callback thread ends up calling
`render_samples()` on the same channel/voice state *at the same time*
as the host's own manual calls, with no coordination between the two.

In practice this produced a data race that manifested as roughly-
doubled playback speed and audio noise/distortion.

## Why not just skip `Audio::start()` in headless mode?

That was the original approach in this PR, but it conflicts with
v2.8.5 ("Enabled audio playback in headless mode"): that release
deliberately made headless mode still produce real audio through SDL2,
for the (different, legitimate) use case of a headless script that
wants to hear sound without opening a window. Unconditionally skipping
`Audio::start()` in headless mode would silently take that feature
away from anyone relying on it — not something this PR should decide
for all users.

## This PR's approach

A new Cargo feature, `no_headless_audio`, changes the behavior only
for crates that explicitly opt in — the same pattern already used by
this crate's own `sdl2_dynamic`/`sdl2_static` features. Default
behavior (feature disabled) is completely unchanged from v2.8.5.

The change is contained entirely within the audio module:
`Audio::start()` is split into two `#[cfg]`-gated implementations, one
per feature state. `pyxel.rs`'s `init()` (and every other caller of
`Audio::start()`) needs no logic changes — it keeps calling the same
unconditional `Audio::start();` either way. This only required exposing
the platform layer's existing (previously private) headless flag as a
small new public `platform::is_headless()`, so `audio.rs` can check it
itself.

One short comment was added directly above the `Audio::start();` call
in `pyxel.rs`, pointing at `audio.rs`'s own `#[cfg]`-gated
implementations rather than restating their rationale — that
duplication was flagged during a `docs/coding-policy.md` self-review
and trimmed (see below).

## Testing

This feature only changes whether `Audio::start()` opens a real SDL2
audio device — an inherently platform-dependent side effect, not
platform-independent pure logic. Per this project's own four-layer
testing model (Rust unit tests / Python API tests / reference
regression / manual pass), that places it in the **manual pass**
layer, not the Rust-unit-test layer, so no Rust test was added for it.

Verified on real hardware (a libretro core built against this branch):

- **Feature enabled**: audio plays back correctly, at the intended
  speed, no distortion.
- **Feature disabled** (default): the original double-speed/distortion
  symptom reliably reproduces, confirming this isn't a coincidental
  fix and that default behavior is unaffected either way.

## Coding policy self-review

Before re-requesting review, this diff was checked against
`docs/coding-policy.md`:

- `Cargo.toml`'s `[features]` table is now alphabetized
  (`no_headless_audio` before `sdl2_dynamic`/`sdl2_static`).
- The `pyxel.rs` comment no longer restates `audio.rs`'s own rationale
  (comment ownership) — it points there instead.
- A `CHANGELOG.md` entry was added under `## 2.9.8` (feature flag
  addition).
- Rebased onto the latest `upstream/main` (including the recent audio
  reliability work) rather than the stale base this PR was originally
  opened against.
