### PR TITLE
Re-export Screencast at the crate root

### DIFF
--- a/crates/pyxel-core/src/lib.rs
+++ b/crates/pyxel-core/src/lib.rs
@@ -73,6 +73,7 @@ pub use crate::pyxel::{
     reset_callback, screen, sounds, tilemaps, tones, validate_init_params, width, AudioGlobalGuard,
     Pyxel,
 };
+pub use crate::screencast::Screencast;
 pub use crate::settings::*;
 pub use crate::sound::{
     RcSound, Sound, SoundEffect, SoundNote, SoundSpeed, SoundTone, SoundVolume,


### PR DESCRIPTION
Hello! Thank you again for maintaining Pyxel.

This is a small follow-up PR from the same project as #714
(lr-pyxel, a libretro core for Lakka). Please let me know if
anything needs adjusting.

And the following description is generated by claude.

## Expose Screencast struct in pyxel-core public API

### Summary

Add one line to `crates/pyxel-core/src/lib.rs`:

```rust
pub use crate::screencast::Screencast;
```

This makes `Screencast::new()`/`capture()`/`save()` — all already
`pub` inside the crate — accessible to external crates, the same way
`Sound`, `Music`, `Tone`, `Channel`, `Font`, `Tilemap`, and `Image`
already are.

### Motivation

`Screencast` (`screencast.rs`) has a fully public API surface, but the
module itself was never re-exported at the crate root via `pub use`,
unlike every other similarly-shaped resource type. Each individual method (`new`/`capture`/`save`) already has `pub`
visibility, so it looks like external use may have been intended —
if so, we'd appreciate it if the module itself could be re-exported
too, the same way downstream projects like lr-pyxel already rely on
for the other resource types.

A downstream embedder that owns its own `Pyxel` singleton lifecycle
(e.g. a libretro core, where the singleton is constructed once at
process bootstrap, before any script's own `pyxel.init()` call runs)
has no way to reconfigure the singleton's internal `Screencast`
capture duration afterward — there's no public setter, and the
singleton itself can only be constructed once. Building an
independent `Screencast` instance, sized from whatever a script
actually requests, is the natural workaround — but it requires the
type itself to be nameable from outside the crate first.

### Solution

Same shape as #714: a single, minimal re-export, no other
`pyxel-core` internals touched.

```rust
// crates/pyxel-core/src/lib.rs
pub use crate::pyxel::{ ... };
pub use crate::screencast::Screencast;      // ← this PR
pub use crate::settings::*;
```

### Real-world usage

This change is used in [lr-pyxel](https://github.com/ShigeakiAsai/lr-pyxel)
(the same project referenced in #714) to honor a script's own
`pyxel.init(capture_sec=...)` request for `screencast()`. The `Pyxel`
singleton's own internal `Screencast` is sized once, at process
bootstrap, before any script's `pyxel.init()` call ever runs, with no
public setter to resize it afterward — an independent `Screencast`
instance, built fresh from whatever `capture_sec` a script actually
requests, is the workaround.

- Verified on Raspberry Pi 5 / aarch64 / Lakka v6.1
- A deliberately short `capture_sec` (2s at 20fps, a ~40-frame ring
  buffer) ran past enough frames to wrap the buffer repeatedly, then
  `screencast()` still saved a valid GIF — confirming the re-exported
  type behaves identically to how the singleton's own internal
  instance already does

### Changes

| File | Change |
| --- | --- |
| `crates/pyxel-core/src/lib.rs` | +1 line: `pub use crate::screencast::Screencast;` |

### Testing

Existing test suite: no changes to logic, only visibility is widened.

Thanks,
ASAI, Shigeaki
